### PR TITLE
[3d-text] Add cjs to rollup, fix package.json:main

### DIFF
--- a/packages/troika-3d-text/package.json
+++ b/packages/troika-3d-text/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/troika-3d-text"
   },
   "license": "MIT",
-  "main": "dist/troika-3d-text.umd.js",
+  "main": "dist/troika-3d-text.cjs.js",
   "browser": "dist/troika-3d-text.umd.js",
   "jsnext:main": "dist/troika-3d-text.esm.js",
   "module": "dist/troika-3d-text.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -79,6 +79,19 @@ for (let entry of Object.keys(entries)) {
       ],
       onwarn
     },
+    // CJS file
+    {
+      input: entry,
+      output: {
+        format: 'cjs',
+        file: `dist/${outFilePrefix}.cjs.js`,
+      },
+      external: Object.keys(EXTERNAL_GLOBALS),
+      plugins: [
+        buble()
+      ],
+      onwarn
+    },
     // UMD file
     {
       input: entry,


### PR DESCRIPTION
This PR adds .cjs.js to /dist and fixes "main" in package.json which normally contains transpiled CJS, browser contains UMD, and module ESM. I guess this should be done for all packages, but what do you think?