### PR TITLE
Update find-google-font-url.js

### DIFF
--- a/packages/troika-3d-text/find-google-font-url.js
+++ b/packages/troika-3d-text/find-google-font-url.js
@@ -17,7 +17,7 @@ if (!fontFamilyName) {
 }
 
 async function run() {
-  const response = await fetch(`https://fonts.googleapis.com/css?family=${fontFamilyName}`, {
+  const response = await fetch(`https://fonts.googleapis.com/css2?family=${fontFamilyName}&display=swap`, {
     "credentials": "omit",
     "headers": {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko",


### PR DESCRIPTION
previsously:

```bash
❯ node font.js Raleway:wght@800
Use this URL for the font family Raleway:wght@800:
https://fonts.gstatic.com/s/raleway/v14/1Ptug8zYS_SKggPNyC0ISQ.woff

❯ node font.js Raleway:wght@200
Use this URL for the font family Raleway:wght@200:
https://fonts.gstatic.com/s/raleway/v14/1Ptug8zYS_SKggPNyC0ISQ.woff
```

😕 same font, the 100wght variant

using the css2 api:

```bash
❯ node font.js Raleway:wght@800
Use this URL for the font family Raleway:wght@800:
https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwIouaqI.woff
```

👍🙂