### PR TITLE
Fix add check for test env in troika worker utils

### DIFF
--- a/packages/troika-worker-utils/src/supportsWorkers.js
+++ b/packages/troika-worker-utils/src/supportsWorkers.js
@@ -8,14 +8,16 @@ let supportsWorkers = () => {
       // TODO additional checks for things like importScripts within the worker?
       //  Would need to be an async check.
       let worker = new Worker(
-        URL.createObjectURL(
-          new Blob([''], { type: 'application/javascript' })
-        )
+        URL.createObjectURL(new Blob([''], { type: 'application/javascript' }))
       )
       worker.terminate()
       supported = true
     } catch (err) {
-      console.log(`Troika createWorkerModule: web workers not allowed; falling back to main thread execution. Cause: [${err.message}]`)
+      if (process.env.NODE_ENV !== 'test') {
+        console.log(
+          `Troika createWorkerModule: web workers not allowed; falling back to main thread execution. Cause: [${err.message}]`
+        )
+      }
     }
   }
 

--- a/packages/troika-worker-utils/src/supportsWorkers.js
+++ b/packages/troika-worker-utils/src/supportsWorkers.js
@@ -13,7 +13,9 @@ let supportsWorkers = () => {
       worker.terminate()
       supported = true
     } catch (err) {
-      if (process.env.NODE_ENV !== 'test') {
+      if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
+        // No console log for node env 'test' (e.g. tests with Jest)
+      } else {
         console.log(
           `Troika createWorkerModule: web workers not allowed; falling back to main thread execution. Cause: [${err.message}]`
         )


### PR DESCRIPTION
I just added a short check to ensure no unnecessary console logs in troika-worker-utils are produced. Otherwise, the console log might irritate devs that are using troika and are receiving this console log in their project's tests, as it is the case in our project.