### PR TITLE
fix: add three 0.128.x to list of valid troika-three-utils versions

### DIFF
--- a/packages/troika-three-utils/package.json
+++ b/packages/troika-three-utils/package.json
@@ -14,6 +14,6 @@
   "module": "dist/troika-three-utils.esm.js",
   "module:src": "src/index.js",
   "peerDependencies": {
-    "three": "0.103.x - 0.127.x"
+    "three": "0.103.x - 0.128.x"
   }
 }


### PR DESCRIPTION
@lojjic Maybe something like `>= 0.103.x` would make more sense? In case it breaks with a specific version it could be narrowed down. RIght now it seems a bit annoying having to bump it with every release 🤔 