### PR TITLE
adding support for Matrix3/4

### DIFF
--- a/packages/three-instanced-uniforms-mesh/README.md
+++ b/packages/three-instanced-uniforms-mesh/README.md
@@ -36,12 +36,14 @@ While this is obviously useful for Three.js's built in materials, it _really_ sh
 
 The type of the `value` argument should match the type of the uniform defined in the material's shader:
 
-| For a uniform of type: | Pass a value of this type:       |
-| ---------------------- | -------------------------------- |
-| float                  | Number                           |
-| vec2                   | `THREE.Vector2`                  |
+| For a uniform of type: | Pass a value of this type:      |
+|------------------------|---------------------------------|
+| float                  | Number                          |
+| vec2                   | `THREE.Vector2`                 |
 | vec3                   | `THREE.Vector3` or `THREE.Color` |
-| vec4                   | `THREE.Vector4`                  |
+| vec4                   | `THREE.Vector4`                 |
+| mat3                   | `THREE.Matrix3`                 |
+| mat4                   | `THREE.Matrix4`                 |
 
 
 ### Resetting to defaults

--- a/packages/three-instanced-uniforms-mesh/package.json
+++ b/packages/three-instanced-uniforms-mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-instanced-uniforms-mesh",
-  "version": "0.44.1",
+  "version": "0.44.0",
   "description": "Extension to Three.js InstancedMesh supporting per-instance uniform values",
   "author": "Jason Johnston <jason.johnston@protectwise.com>",
   "repository": {

--- a/packages/three-instanced-uniforms-mesh/package.json
+++ b/packages/three-instanced-uniforms-mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-instanced-uniforms-mesh",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Extension to Three.js InstancedMesh supporting per-instance uniform values",
   "author": "Jason Johnston <jason.johnston@protectwise.com>",
   "repository": {

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsDerivedMaterial.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsDerivedMaterial.js
@@ -26,9 +26,9 @@ export function createInstancedUniformsDerivedMaterial (baseMaterial) {
         let fragType = fragmentUniforms[name]
         const type = vertType || fragType
         if (type) {
-          // remove existing deklarations
-          const findDeklaration = new RegExp(`\\s*(?:varying|attribute|uniform)\\s+${type}\\s+${name}\\s*;?`, 'g')
-          vertexShader = vertexShader.replaceAll(findDeklaration,"")
+          // remove existing declarations
+          const findDeclaration = new RegExp(`\\s*(?:varying|attribute|uniform)\\s+${type}\\s+${name}\\s*;?`, 'g')
+          vertexShader = vertexShader.replaceAll(findDeclaration,"")
 
           let finder = new RegExp(`\\b${name}\\b`, 'g')
           vertexDeclarations.push(`attribute ${type} troika_attr_${name};`)

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsDerivedMaterial.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsDerivedMaterial.js
@@ -24,9 +24,14 @@ export function createInstancedUniformsDerivedMaterial (baseMaterial) {
       _uniformNames.forEach((name) => {
         let vertType = vertexUniforms[name]
         let fragType = fragmentUniforms[name]
-        if (vertType || fragType) {
+        const type = vertType || fragType
+        if (type) {
+          // remove existing deklarations
+          const findDeklaration = new RegExp(`\\s*(?:varying|attribute|uniform)\\s+${type}\\s+${name}\\s*;?`, 'g')
+          vertexShader = vertexShader.replaceAll(findDeklaration,"")
+
           let finder = new RegExp(`\\b${name}\\b`, 'g')
-          vertexDeclarations.push(`attribute ${vertType || fragType} troika_attr_${name};`)
+          vertexDeclarations.push(`attribute ${type} troika_attr_${name};`)
           if (vertType) {
             vertexShader = vertexShader.replace(finder, attrRefReplacer)
           }

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
@@ -122,8 +122,8 @@ function setAttributeValue (attr, index, value) {
     }
   } else if (size === 4) {
     attr.setXYZW(index, value.x, value.y, value.z, value.w)
-  } else if (value?.toArray) {
-    value.toArray(attr, index * size)
+  } else if (value.toArray) {
+    value.toArray(attr.array, index * size)
   } else {
     attr.set(value, index * size)
   }
@@ -148,7 +148,7 @@ function getItemSizeForValue (value) {
     : value.isVector2 ? 2
     : value.isVector3 || value.isColor ? 3
     : value.isVector4 || value.isQuaternion ? 4
-    : value?.elements ? value.elements.length
+    : value.elements ? value.elements.length
     : Array.isArray(value) ? value.length
     : 0
 }

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
@@ -75,7 +75,7 @@ export class InstancedUniformsMesh extends InstancedMesh {
    * Set the value of a shader uniform for a single instance.
    * @param {string} name - the name of the shader uniform
    * @param {number} index - the index of the instance to set the value for
-   * @param {number|Vector2|Vector3|Vector4|Color|Array} value - the uniform value for this instance
+   * @param {number|Vector2|Vector3|Vector4|Color|Array|Matrix3|Matrix4|Quaternion} value - the uniform value for this instance
    */
   setUniformAt (name, index, value) {
     const attrs = this.geometry.attributes
@@ -122,6 +122,10 @@ function setAttributeValue (attr, index, value) {
     }
   } else if (size === 4) {
     attr.setXYZW(index, value.x, value.y, value.z, value.w)
+  } else if (value?.toArray) {
+    value.toArray(attr, index)
+  } else {
+    attr.set(index, value)
   }
 }
 
@@ -143,7 +147,8 @@ function getItemSizeForValue (value) {
     : typeof value === 'number' ? 1
     : value.isVector2 ? 2
     : value.isVector3 || value.isColor ? 3
-    : value.isVector4 ? 4
+    : value.isVector4 || value.isQuaternion ? 4
+    : value?.elements ? value.elements.length
     : Array.isArray(value) ? value.length
     : 0
 }

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
@@ -123,9 +123,9 @@ function setAttributeValue (attr, index, value) {
   } else if (size === 4) {
     attr.setXYZW(index, value.x, value.y, value.z, value.w)
   } else if (value?.toArray) {
-    value.toArray(attr, index)
+    value.toArray(attr, index * size)
   } else {
-    attr.set(index, value)
+    attr.set(value, index * size)
   }
 }
 

--- a/packages/troika-three-utils/src/getShaderUniformTypes.js
+++ b/packages/troika-three-utils/src/getShaderUniformTypes.js
@@ -5,7 +5,7 @@
  * @return {object} mapping of uniform names to their glsl type
  */
 export function getShaderUniformTypes(shader) {
-  let uniformRE = /\buniform\s+(int|float|vec[234])\s+([A-Za-z_][\w]*)/g
+  let uniformRE = /\buniform\s+(int|float|vec[234]|mat3|mat4)\s+([A-Za-z_][\w]*)/g
   let uniforms = Object.create(null)
   let match
   while ((match = uniformRE.exec(shader)) !== null) {


### PR DESCRIPTION
Hi,

thanks a lot for this great library! I needed to set the "uvTransform" - attribute, which wasn't supported, so I extended the three-instanced-uniforms-mesh to support matrix3/4 (and I guess I also fixed array support). Another change is that I needed to remove previous declarations of uvTransform in the shader (see createInstancedUniformsDerivedMaterial line 30). I would be glad if this PR could be integrated. If there is any problem, please let me know.

Cheers,
Sebastian