### PR TITLE
Rename "distance" variable in shader

### DIFF
--- a/packages/troika-three-text/src/TextDerivedMaterial.js
+++ b/packages/troika-three-text/src/TextDerivedMaterial.js
@@ -179,10 +179,10 @@ float troikaGetEdgeAlpha(float distance, float distanceOffset, float aaDist) {
 // language=GLSL prefix="void main() {" suffix="}"
 const FRAGMENT_TRANSFORM = `
 float aaDist = troikaGetAADist();
-float distance = troikaGetFragDistValue();
+float fragDistance = troikaGetFragDistValue();
 float edgeAlpha = uTroikaSDFDebug ?
   troikaGlyphUvToSdfValue(vTroikaGlyphUV) :
-  troikaGetEdgeAlpha(distance, uTroikaDistanceOffset, max(aaDist, uTroikaBlurRadius));
+  troikaGetEdgeAlpha(fragDistance, uTroikaDistanceOffset, max(aaDist, uTroikaBlurRadius));
 
 #if !defined(IS_DEPTH_MATERIAL) && !defined(IS_DISTANCE_MATERIAL)
 vec4 fillRGBA = gl_FragColor;
@@ -192,7 +192,7 @@ if (fillRGBA.a == 0.0) fillRGBA.rgb = strokeRGBA.rgb;
 gl_FragColor = mix(fillRGBA, strokeRGBA, smoothstep(
   -uTroikaStrokeWidth - aaDist,
   -uTroikaStrokeWidth + aaDist,
-  distance
+  fragDistance
 ));
 gl_FragColor.a *= edgeAlpha;
 #endif


### PR DESCRIPTION
Rename the `distance` variable because it may create a conflict with the builtin GLSL `distance` function : 
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/distance.xhtml

I stumbled upon this problem when changing default threejs shader chunks to use the `distance` function in fog calculations... it could not compile troika shader and gave me this error message : `'distance' : function name expected`

_Note: there are other variables named `distance` elsewhere (inside `troikaGetFragDistValue()` and `troikaGetEdgeAlpha()`) which I did not change since its inside a function, it does not "bleed out" and break other stuff._

Thank you ! 🙂 