### PR TITLE
troika-three-text: Don't break line when &nbsp; is encountered

### DIFF
--- a/packages/troika-three-text/src/Typesetter.js
+++ b/packages/troika-three-text/src/Typesetter.js
@@ -48,9 +48,12 @@ export function createTypesetter(fontParser, bidi, config) {
   // Set of Unicode Default_Ignorable_Code_Point characters, these will not produce visible glyphs
   const DEFAULT_IGNORABLE_CHARS = /[\u00AD\u034F\u061C\u115F-\u1160\u17B4-\u17B5\u180B-\u180E\u200B-\u200F\u202A-\u202E\u2060-\u206F\u3164\uFE00-\uFE0F\uFEFF\uFFA0\uFFF0-\uFFF8]/
 
+  // This regex (instead of /\s/) allows us to select all whitespace EXCEPT for non-breaking white spaces
+  const lineBreakingWhiteSpace = `[^\\S\\u00A0]`
+
   // Incomplete set of characters that allow line breaking after them
   // In the future we may consider a full Unicode line breaking algorithm impl: https://www.unicode.org/reports/tr14
-  const BREAK_AFTER_CHARS = /[\s\-\u007C\u00AD\u2010\u2012-\u2014\u2027\u2056\u2E17\u2E40]/
+  const BREAK_AFTER_CHARS = new RegExp(`${lineBreakingWhiteSpace}|[\\-\\u007C\\u00AD\\u2010\\u2012-\\u2014\\u2027\\u2056\\u2E17\\u2E40]`)
 
   /**
    * Load a given font url
@@ -206,7 +209,7 @@ export function createTypesetter(fontParser, bidi, config) {
 
         // Calc isWhitespace and isEmpty once per glyphObj
         if (!('isEmpty' in glyphObj)) {
-          glyphObj.isWhitespace = !!char && /\s/.test(char)
+          glyphObj.isWhitespace = !!char && new RegExp(lineBreakingWhiteSpace).test(char)
           glyphObj.canBreakAfter = !!char && BREAK_AFTER_CHARS.test(char)
           glyphObj.isEmpty = glyphObj.xMin === glyphObj.xMax || glyphObj.yMin === glyphObj.yMax || DEFAULT_IGNORABLE_CHARS.test(char)
         }


### PR DESCRIPTION
Hello! This PR updates troika-three-text so that users can use the "Non-breaking space" character (https://en.wikipedia.org/wiki/Non-breaking_space) without causing a linebreak.

This is done by updating the use of `\s` (whitespace selector) to be `[^\S\u00A0]` – which is a negating selector group that doesn't select everything that is _not_ a whitespace character or a non-breaking space character. Functionally, this can be simplified to "whitespace characters except u00A0".