### PR TITLE
allow InstancedUniformsMesh.count to be dynamic

### DIFF
--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
@@ -5,6 +5,7 @@ import { createInstancedUniformsDerivedMaterial } from './InstancedUniformsDeriv
 export class InstancedUniformsMesh extends InstancedMesh {
   constructor (geometry, material, count) {
     super(geometry, material, count)
+    this._maxCount = count;
     this._instancedUniformNames = [] //treated as immutable
   }
 
@@ -84,10 +85,10 @@ export class InstancedUniformsMesh extends InstancedMesh {
     if (!attr) {
       const defaultValue = getDefaultUniformValue(this._baseMaterial, name)
       const itemSize = getItemSizeForValue(defaultValue)
-      attr = attrs[attrName] = new InstancedBufferAttribute(new Float32Array(itemSize * this.count), itemSize)
+      attr = attrs[attrName] = new InstancedBufferAttribute(new Float32Array(itemSize * this._maxCount), itemSize)
       // Fill with default value:
       if (defaultValue !== null) {
-        for (let i = 0; i < this.count; i++) {
+        for (let i = 0; i < this._maxCount; i++) {
           setAttributeValue(attr, i, defaultValue)
         }
       }


### PR DESCRIPTION
This is a bugfix for the count property of InstancedUniformsMesh. According to the three documentation of [InstancedMesh.count](https://threejs.org/docs/?q=InstancedMesh#api/en/objects/InstancedMesh.count):

_The count value passed into the constructor represents the maximum number of instances of this mesh. You can change the number of instances at runtime to an integer value in the range [0, count]._

Without this bugfix, the size of the InstancedBufferAttribute will be wrong in situations when the count property changes over time.
