### PR TITLE
Prevent PlaneBufferGeometry rename warning

### DIFF
--- a/packages/troika-three-text/src/GlyphsGeometry.js
+++ b/packages/troika-three-text/src/GlyphsGeometry.js
@@ -1,7 +1,6 @@
 import {
   Float32BufferAttribute,
   BufferGeometry,
-  PlaneBufferGeometry,
   InstancedBufferGeometry,
   InstancedBufferAttribute,
   Sphere,
@@ -9,6 +8,7 @@ import {
   DoubleSide,
   BackSide,
 } from 'three'
+import { PlaneGeometry } from './ThreeCompatibility.js'
 
 const GlyphsGeometry = /*#__PURE__*/(() => {
 
@@ -20,7 +20,7 @@ const GlyphsGeometry = /*#__PURE__*/(() => {
       // appear as DoubleSide by default. FrontSide/BackSide are emulated using drawRange.
       // We do it this way to avoid the performance hit of two draw calls for DoubleSide materials
       // introduced by Three.js in r130 - see https://github.com/mrdoob/three.js/pull/21967
-      const front = new PlaneBufferGeometry(1, 1, detail, detail)
+      const front = new PlaneGeometry(1, 1, detail, detail)
       const back = front.clone()
       const frontAttrs = front.attributes
       const backAttrs = back.attributes

--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -5,10 +5,10 @@ import {
   Matrix4,
   Mesh,
   MeshBasicMaterial,
-  PlaneBufferGeometry,
   Vector3,
   Vector2,
 } from 'three'
+import { PlaneGeometry } from './ThreeCompatibility.js'
 import { GlyphsGeometry } from './GlyphsGeometry.js'
 import { createTextDerivedMaterial } from './TextDerivedMaterial.js'
 import { getTextRenderInfo } from './TextBuilder.js'
@@ -35,7 +35,7 @@ const Text = /*#__PURE__*/(() => {
 
   let getFlatRaycastMesh = () => {
     const mesh = new Mesh(
-      new PlaneBufferGeometry(1, 1),
+      new PlaneGeometry(1, 1),
       defaultMaterial
     )
     getFlatRaycastMesh = () => mesh
@@ -43,7 +43,7 @@ const Text = /*#__PURE__*/(() => {
   }
   let getCurvedRaycastMesh = () => {
     const mesh = new Mesh(
-      new PlaneBufferGeometry(1, 1, 32, 1),
+      new PlaneGeometry(1, 1, 32, 1),
       defaultMaterial
     )
     getCurvedRaycastMesh = () => mesh

--- a/packages/troika-three-text/src/ThreeCompatibility.js
+++ b/packages/troika-three-text/src/ThreeCompatibility.js
@@ -1,0 +1,18 @@
+/**
+ * A module exposing the right classes for the current Three.js version used.
+ */
+
+import {
+  REVISION,
+  PlaneBufferGeometry,
+  PlaneGeometry
+} from 'three'
+
+// The revision number was a string at some point (ex: in r103)
+const version = Number(REVISION)
+
+// Since r144, a warning is shown when a PlaneBufferGeometry is created
+// See PR #24352, https://github.com/mrdoob/three.js/blob/a09adf3d96fdd508cdf46434fb071f05b84e7bce/src/Three.Legacy.js#L205
+const planeGeometryClass = version >= 144 ? PlaneGeometry : PlaneBufferGeometry
+
+export { planeGeometryClass as PlaneGeometry }


### PR DESCRIPTION
My suggestion to fix https://github.com/protectwise/troika/issues/192#issuecomment-1239951110
(unwanted warning in console : `THREE.PlaneBufferGeometry has been renamed to THREE.PlaneGeometry.`)

I only tested it with r145, but according to [your package.json](https://github.com/protectwise/troika/blob/5fa65fe386fe8e832fcf5972a569ec3f711b0e07/packages/troika-three-text/package.json#L23), `troika-three-text` supports three.js from r103, so I used [this CDN link](https://cdnjs.cloudflare.com/ajax/libs/three.js/103/three.js) as a reference to help determine what checks to perform.

Feel free to use this approach or not 🙂

Thanks !