### PR TITLE
fix!: r144 geometry rename

### DIFF
--- a/docs/troika-3d/objects.md
+++ b/docs/troika-3d/objects.md
@@ -33,11 +33,11 @@ An example using `initThreeObject()`:
 
 ```js
 import { Object3DFacade } from 'troika-3d'
-import { Mesh, BoxBufferGeometry, MeshStandardMaterial } from 'three'
+import { Mesh, BoxGeometry, MeshStandardMaterial } from 'three'
 
 // It's often to define a singleton geometry instance that can be used
 // across all instances of this object type:
-const geometry = new BoxBufferGeometry()
+const geometry = new BoxGeometry()
 
 class MyObject extends Object3DFacade {
   initThreeObject() {

--- a/packages/three-instanced-uniforms-mesh/package.json
+++ b/packages/three-instanced-uniforms-mesh/package.json
@@ -17,6 +17,6 @@
     "troika-three-utils": "^0.46.0"
   },
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   }
 }

--- a/packages/troika-3d-text/package.json
+++ b/packages/troika-3d-text/package.json
@@ -19,6 +19,6 @@
     "troika-three-utils": "^0.46.0"
   },
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   }
 }

--- a/packages/troika-3d-text/src/facade/SelectionRangeRect.js
+++ b/packages/troika-3d-text/src/facade/SelectionRangeRect.js
@@ -1,4 +1,4 @@
-import { BoxBufferGeometry, Color, Mesh, MeshBasicMaterial, Vector2, Vector4 } from 'three'
+import { BoxGeometry, Color, Mesh, MeshBasicMaterial, Vector2, Vector4 } from 'three'
 import {Instanceable3DFacade, createDerivedMaterial} from 'troika-3d'
 
 const tempVec4 = new Vector4()
@@ -35,11 +35,11 @@ if (rad != 0.0) {
   )
   const meshes = {
     normal: new Mesh(
-      new BoxBufferGeometry(1, 1, 1).translate(0.5, 0.5, 0.5),
+      new BoxGeometry(1, 1, 1).translate(0.5, 0.5, 0.5),
       material
     ),
     curved: new Mesh(
-      new BoxBufferGeometry(1, 1, 1, 32).translate(0.5, 0.5, 0.5),
+      new BoxGeometry(1, 1, 1, 32).translate(0.5, 0.5, 0.5),
       material
     )
   }

--- a/packages/troika-3d-ui/package.json
+++ b/packages/troika-3d-ui/package.json
@@ -22,6 +22,6 @@
     "troika-three-utils": "^0.46.0"
   },
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   }
 }

--- a/packages/troika-3d-ui/src/facade/ScrollbarsFacade.js
+++ b/packages/troika-3d-ui/src/facade/ScrollbarsFacade.js
@@ -1,5 +1,5 @@
 import { Object3DFacade, ParentFacade } from 'troika-3d'
-import { CylinderBufferGeometry, Mesh, MeshBasicMaterial } from 'three'
+import { CylinderGeometry, Mesh, MeshBasicMaterial } from 'three'
 
 let barGeometry
 
@@ -8,7 +8,7 @@ class ScrollbarBarFacade extends Object3DFacade {
   constructor(parent) {
     const mesh = new Mesh(
       barGeometry || (barGeometry =
-        new CylinderBufferGeometry(0.5, 0.5, 1, 8).translate(0, -0.5, 0)
+        new CylinderGeometry(0.5, 0.5, 1, 8).translate(0, -0.5, 0)
       ),
       // TODO allow overriding material
       new MeshBasicMaterial({

--- a/packages/troika-3d-ui/src/facade/UIBlock3DFacade.js
+++ b/packages/troika-3d-ui/src/facade/UIBlock3DFacade.js
@@ -1,4 +1,4 @@
-import { Mesh, Vector2, Vector3, Vector4, PlaneBufferGeometry, Sphere, Matrix4, Plane } from 'three'
+import { Mesh, Vector2, Vector3, Vector4, PlaneGeometry, Sphere, Matrix4, Plane } from 'three'
 import { Group3DFacade } from 'troika-3d'
 import UITextNode3DFacade from './UITextNode3DFacade.js'
 import UIBlockLayer3DFacade from './UIBlockLayer3DFacade.js'
@@ -7,7 +7,7 @@ import { getComputedFontSize, getInheritable, INHERITABLES } from '../uiUtils.js
 import ScrollbarsFacade from './ScrollbarsFacade.js'
 import { invertMatrix4 } from 'troika-three-utils'
 
-const raycastMesh = new Mesh(new PlaneBufferGeometry(1, 1).translate(0.5, -0.5, 0))
+const raycastMesh = new Mesh(new PlaneGeometry(1, 1).translate(0.5, -0.5, 0))
 const tempMat4 = new Matrix4()
 const tempVec4 = new Vector4(0,0,0,0)
 const emptyVec4 = Object.freeze(new Vector4(0,0,0,0))

--- a/packages/troika-3d-ui/src/facade/UIBlockLayer3DFacade.js
+++ b/packages/troika-3d-ui/src/facade/UIBlockLayer3DFacade.js
@@ -1,8 +1,8 @@
 import { Instanceable3DFacade } from 'troika-3d'
-import { Color, Mesh, MeshBasicMaterial, PlaneBufferGeometry, Vector2, Vector4 } from 'three'
+import { Color, Mesh, MeshBasicMaterial, PlaneGeometry, Vector2, Vector4 } from 'three'
 import { createUIBlockLayerDerivedMaterial } from './UIBlockLayerDerivedMaterial.js'
 
-const geometry = new PlaneBufferGeometry(1, 1).translate(0.5, -0.5, 0)
+const geometry = new PlaneGeometry(1, 1).translate(0.5, -0.5, 0)
 const defaultMaterial = new MeshBasicMaterial({color: 0})
 const emptyVec2 = Object.freeze(new Vector2())
 const emptyVec4 = Object.freeze(new Vector4(0,0,0,0))

--- a/packages/troika-3d-ui/src/facade/UIImage3DFacade.js
+++ b/packages/troika-3d-ui/src/facade/UIImage3DFacade.js
@@ -1,9 +1,9 @@
 import { extendAsFlexNode } from '../flex-layout/FlexNode.js'
-import { Mesh, MeshBasicMaterial, PlaneBufferGeometry, TextureLoader } from 'three'
+import { Mesh, MeshBasicMaterial, PlaneGeometry, TextureLoader } from 'three'
 import { Object3DFacade } from 'troika-3d'
 
 
-const geometry = new PlaneBufferGeometry(1, 1).translate(0.5, -0.5, 0)
+const geometry = new PlaneGeometry(1, 1).translate(0.5, -0.5, 0)
 const defaultMaterial = new MeshBasicMaterial()
 const loader = new TextureLoader()
 

--- a/packages/troika-3d-ui/src/facade/widgets/ColorPickerFacade.js
+++ b/packages/troika-3d-ui/src/facade/widgets/ColorPickerFacade.js
@@ -2,12 +2,12 @@ import { Group3DFacade, Object3DFacade } from 'troika-3d'
 import {
   BackSide,
   Color,
-  CylinderBufferGeometry,
+  CylinderGeometry,
   Mesh,
   MeshBasicMaterial,
   Plane,
-  PlaneBufferGeometry,
-  SphereBufferGeometry,
+  PlaneGeometry,
+  SphereGeometry,
   Vector3
 } from 'three'
 import { createDerivedMaterial } from 'troika-three-utils'
@@ -72,7 +72,7 @@ function rgb2hsv (r, g, b) {
   return [h, s, v]
 }
 
-const cylinderGeometry = new CylinderBufferGeometry(0.5, 0.5, 1, 45)
+const cylinderGeometry = new CylinderGeometry(0.5, 0.5, 1, 45)
   .translate(0, 0.5, 0)
   .rotateX(Math.PI / 2)
   .rotateZ(Math.PI / 2) //orient uv
@@ -145,9 +145,9 @@ class HsvCylinderBg extends Object3DFacade {
 
 class ValueStick extends Object3DFacade {
   constructor (parent) {
-    const ballGeom = new SphereBufferGeometry(0.05, 16, 12)
+    const ballGeom = new SphereGeometry(0.05, 16, 12)
       .translate(0, 0, 0.5)
-    const stickGeom = new CylinderBufferGeometry(0.005, 0.005, 0.5, 6)
+    const stickGeom = new CylinderGeometry(0.005, 0.005, 0.5, 6)
       .translate(0, 0.25, 0).rotateX(Math.PI / 2)
 
     const material = new MeshBasicMaterial()
@@ -180,7 +180,7 @@ class ValuePlane extends Object3DFacade {
       `
     })
     super(parent, new Mesh(
-      new PlaneBufferGeometry(),
+      new PlaneGeometry(),
       material
     ))
   }

--- a/packages/troika-3d/package.json
+++ b/packages/troika-3d/package.json
@@ -18,6 +18,6 @@
     "troika-three-utils": "^0.46.0"
   },
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   }
 }

--- a/packages/troika-3d/src/facade/primitives/BoxFacade.js
+++ b/packages/troika-3d/src/facade/primitives/BoxFacade.js
@@ -1,13 +1,13 @@
 import { utils } from 'troika-core'
-import { BoxBufferGeometry } from 'three'
+import { BoxGeometry } from 'three'
 import { MeshFacade } from './MeshFacade.js'
 
 /**
- * Return a singleton instance of a 1x1x1 BoxBufferGeometry
- * @type {function(): BoxBufferGeometry}
+ * Return a singleton instance of a 1x1x1 BoxGeometry
+ * @type {function(): BoxGeometry}
  */
 export const getBoxGeometry = utils.memoize(() => {
-  return new BoxBufferGeometry(1, 1, 1, 1, 1)
+  return new BoxGeometry(1, 1, 1, 1, 1)
 })
 
 

--- a/packages/troika-3d/src/facade/primitives/CircleFacade.js
+++ b/packages/troika-3d/src/facade/primitives/CircleFacade.js
@@ -1,5 +1,5 @@
 import { utils } from 'troika-core'
-import { CircleBufferGeometry, DoubleSide } from 'three'
+import { CircleGeometry, DoubleSide } from 'three'
 import { MeshFacade } from './MeshFacade.js'
 
 const geometries = Object.create(null, [
@@ -9,7 +9,7 @@ const geometries = Object.create(null, [
 ].reduce((descr, [name, segments]) => {
   descr[name] = {
     get: utils.memoize(() =>
-      new CircleBufferGeometry(1, segments).rotateX(-Math.PI / 2)
+      new CircleGeometry(1, segments).rotateX(-Math.PI / 2)
     )
   }
   return descr

--- a/packages/troika-3d/src/facade/primitives/PlaneFacade.js
+++ b/packages/troika-3d/src/facade/primitives/PlaneFacade.js
@@ -1,9 +1,9 @@
 import { utils } from 'troika-core'
-import { DoubleSide, PlaneBufferGeometry } from 'three'
+import { DoubleSide, PlaneGeometry } from 'three'
 import { MeshFacade } from './MeshFacade.js'
 
 const getGeometry = utils.memoize(() => {
-  return new PlaneBufferGeometry(1, 1, 1, 1).rotateX(-Math.PI / 2)
+  return new PlaneGeometry(1, 1, 1, 1).rotateX(-Math.PI / 2)
 })
 
 /**

--- a/packages/troika-3d/src/facade/primitives/SphereFacade.js
+++ b/packages/troika-3d/src/facade/primitives/SphereFacade.js
@@ -1,5 +1,5 @@
 import { utils } from 'troika-core'
-import { SphereBufferGeometry } from 'three'
+import { SphereGeometry } from 'three'
 import { MeshFacade } from './MeshFacade.js'
 
 const geometries = Object.create(null, [
@@ -8,7 +8,7 @@ const geometries = Object.create(null, [
   ['high', 64, 48]
 ].reduce((descr, [name, wSegs, hSegs]) => {
   descr[name] = {
-    get: utils.memoize(() => new SphereBufferGeometry(1, wSegs, hSegs))
+    get: utils.memoize(() => new SphereGeometry(1, wSegs, hSegs))
   }
   return descr
 }, {}))

--- a/packages/troika-examples/arcs/ArcFacade.js
+++ b/packages/troika-examples/arcs/ArcFacade.js
@@ -1,4 +1,4 @@
-import {Mesh, ShaderMaterial, MeshStandardMaterial, BoxBufferGeometry, Color, Sphere, Vector3, DoubleSide} from 'three'
+import {Mesh, ShaderMaterial, MeshStandardMaterial, BoxGeometry, Color, Sphere, Vector3, DoubleSide} from 'three'
 import {Object3DFacade, createDerivedMaterial} from 'troika-3d'
 import arcVertexShader from './arcVertexShader.glsl'
 import arcFragmentShader from './arcFragmentShader.glsl'
@@ -6,7 +6,7 @@ import arcFragmentShader from './arcFragmentShader.glsl'
 const baseColor = new Color(0x3ba7db)
 const highlightColor = new Color(0xffffff)
 
-const baseGeometry = new BoxBufferGeometry(1, 1, 1, 8, 1, 1)
+const baseGeometry = new BoxGeometry(1, 1, 1, 8, 1, 1)
 
 const customShaderMaterial = new ShaderMaterial({
   uniforms: {

--- a/packages/troika-examples/bezier-3d/ShadowSurfaceFacade.js
+++ b/packages/troika-examples/bezier-3d/ShadowSurfaceFacade.js
@@ -1,10 +1,10 @@
 import {Object3DFacade} from 'troika-3d'
-import { Mesh, MeshStandardMaterial, PlaneBufferGeometry } from 'three'
+import { Mesh, MeshStandardMaterial, PlaneGeometry } from 'three'
 
 export default class ShadowSurface extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      new PlaneBufferGeometry(),
+      new PlaneGeometry(),
       new MeshStandardMaterial({
         color: 0x333333,
         roughness: 0.8,

--- a/packages/troika-examples/citygrid/Host.js
+++ b/packages/troika-examples/citygrid/Host.js
@@ -1,4 +1,4 @@
-import {BoxBufferGeometry, MeshLambertMaterial, Color, Mesh, BufferGeometry, BufferAttribute} from 'three'
+import {BoxGeometry, MeshLambertMaterial, Color, Mesh, BufferGeometry, BufferAttribute} from 'three'
 import {Object3DFacade} from 'troika-3d'
 
 /*
@@ -20,7 +20,7 @@ hostGeometry.setAttribute('position', new BufferAttribute(new Float32Array([
   0,0,1, 1,0,1, 1,1,1
 ].map((n, i) => (i + 1) % 3 ? n - 0.5 : n)), 3))
 */
-const hostGeometry = new BoxBufferGeometry(1, 1, 1)
+const hostGeometry = new BoxGeometry(1, 1, 1)
 hostGeometry.translate(0, 0, .5)
 
 const hostMaterials = {

--- a/packages/troika-examples/citygrid/Zone.js
+++ b/packages/troika-examples/citygrid/Zone.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import {Group, Mesh, Line, BufferGeometry, BufferAttribute, CylinderBufferGeometry, MeshLambertMaterial, LineBasicMaterial, DoubleSide} from 'three'
+import {Group, Mesh, Line, BufferGeometry, BufferAttribute, CylinderGeometry, MeshLambertMaterial, LineBasicMaterial, DoubleSide} from 'three'
 import {Object3DFacade, HtmlOverlay3DFacade} from 'troika-3d'
 import Tooltip from './Tooltip.jsx'
 
 
-const wallsGeometry = new CylinderBufferGeometry(Math.sqrt(2) / 2, Math.sqrt(2) / 2, 1, 4, 1, true)
+const wallsGeometry = new CylinderGeometry(Math.sqrt(2) / 2, Math.sqrt(2) / 2, 1, 4, 1, true)
   .rotateY(Math.PI / 4)
   .rotateX(Math.PI / 2)
   .translate(0.5, 0.5, 0.5)

--- a/packages/troika-examples/dragdrop/Planet.js
+++ b/packages/troika-examples/dragdrop/Planet.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshPhongMaterial
 } from 'three'
@@ -8,7 +8,7 @@ import {
 } from 'troika-3d'
 
 
-const geometry = new SphereBufferGeometry(1, 32, 32)
+const geometry = new SphereGeometry(1, 32, 32)
 const material = new MeshPhongMaterial({
   transparent: true
 })

--- a/packages/troika-examples/dragdrop/Sun.js
+++ b/packages/troika-examples/dragdrop/Sun.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshBasicMaterial
 } from 'three'
@@ -8,7 +8,7 @@ import {
 } from 'troika-3d'
 
 
-const geometry = new SphereBufferGeometry(.02, 16, 16)
+const geometry = new SphereGeometry(.02, 16, 16)
 const material = new MeshBasicMaterial({
   color: 0xffffff
 })

--- a/packages/troika-examples/flexbox/FlexboxGlobe.js
+++ b/packages/troika-examples/flexbox/FlexboxGlobe.js
@@ -1,6 +1,6 @@
 import { Object3DFacade } from 'troika-3d'
 import { extendAsFlexNode } from 'troika-3d-ui'
-import { Mesh, MeshStandardMaterial, SphereBufferGeometry, TextureLoader } from 'three'
+import { Mesh, MeshStandardMaterial, SphereGeometry, TextureLoader } from 'three'
 
 /**
  * A globe that participates in flexbox layout
@@ -8,7 +8,7 @@ import { Mesh, MeshStandardMaterial, SphereBufferGeometry, TextureLoader } from 
 class FlexboxGlobe extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      new SphereBufferGeometry(0.5, 64, 64),
+      new SphereGeometry(0.5, 64, 64),
       new MeshStandardMaterial({
         map: new TextureLoader().load('globe/texture_day.jpg'),
         roughness: 0.5,

--- a/packages/troika-examples/globe-connections/Globe.js
+++ b/packages/troika-examples/globe-connections/Globe.js
@@ -8,7 +8,7 @@ import {
   Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
-  SphereBufferGeometry,
+  SphereGeometry,
   Vector3
 } from 'three'
 import geojson from './countries.geojson.json'
@@ -71,7 +71,7 @@ const positionAttr = new BufferAttribute(new Float32Array(lineSegmentPositions),
 countryBordersGeometry.setAttribute('position', positionAttr)
 countryBordersGeometry.setAttribute('normal', positionAttr) //positions are based off r=1 so they can be used directly as normals
 
-const sphereGeometry = new SphereBufferGeometry(1, 32, 24)
+const sphereGeometry = new SphereGeometry(1, 32, 24)
 const sphereMaterial = createDerivedMaterial(new MeshBasicMaterial({
   color: 0x6666ff,
   transparent: true,

--- a/packages/troika-examples/globe/Earth.js
+++ b/packages/troika-examples/globe/Earth.js
@@ -1,6 +1,6 @@
 import {ListFacade} from 'troika-core'
 import {Object3DFacade} from 'troika-3d'
-import {Mesh, MeshPhongMaterial, SphereBufferGeometry, TextureLoader} from 'three'
+import {Mesh, MeshPhongMaterial, SphereGeometry, TextureLoader} from 'three'
 import Country from './Country'
 import geojson from './countries.geojson.json'
 
@@ -21,7 +21,7 @@ Object.keys(geojson).forEach(region => {
 class Earth extends Object3DFacade {
   constructor(parent) {
     let mesh = new Mesh(
-      new SphereBufferGeometry(.995, 64, 64),
+      new SphereGeometry(.995, 64, 64),
       new MeshPhongMaterial()
     )
     super(parent, mesh)

--- a/packages/troika-examples/html-overlays/Box.js
+++ b/packages/troika-examples/html-overlays/Box.js
@@ -1,5 +1,5 @@
 import {
-  BoxBufferGeometry,
+  BoxGeometry,
   Mesh,
   MeshPhongMaterial,
   DoubleSide
@@ -11,7 +11,7 @@ import {
 
 const BOX_SIZE = 40
 
-const geometry = new BoxBufferGeometry(BOX_SIZE, BOX_SIZE, BOX_SIZE)
+const geometry = new BoxGeometry(BOX_SIZE, BOX_SIZE, BOX_SIZE)
 const material = new MeshPhongMaterial({
   color: 0x003300,
   opacity: 0.6,

--- a/packages/troika-examples/html-overlays/Dot.js
+++ b/packages/troika-examples/html-overlays/Dot.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshPhongMaterial
 } from 'three'
@@ -8,7 +8,7 @@ import {
 } from 'troika-3d'
 
 
-const geometry = new SphereBufferGeometry(1)
+const geometry = new SphereGeometry(1)
 const material = new MeshPhongMaterial({
   color: 0x993333
 })

--- a/packages/troika-examples/inception/InceptionExample.jsx
+++ b/packages/troika-examples/inception/InceptionExample.jsx
@@ -1,4 +1,4 @@
-import {BoxBufferGeometry, Mesh, MeshStandardMaterial, SphereBufferGeometry} from 'three'
+import {BoxGeometry, Mesh, MeshStandardMaterial, SphereGeometry} from 'three'
 import {World2DFacade} from 'troika-2d'
 import {makeWorldTextureProvider, Object3DFacade, Canvas3D, World3DFacade} from 'troika-3d'
 import {TwoDeeScene} from '../canvas2d/Canvas2DExample'
@@ -8,8 +8,8 @@ import {refreshArcsData} from '../arcs/arcsData'
 import { ExampleConfigurator } from '../_shared/ExampleConfigurator.js'
 
 
-const sphereGeom = new SphereBufferGeometry(0.5, 32, 32)
-const boxGeom = new BoxBufferGeometry(1, 1, 1)
+const sphereGeom = new SphereGeometry(0.5, 32, 32)
+const boxGeom = new BoxGeometry(1, 1, 1)
 
 class WorldTexturedSphere extends Object3DFacade {
   constructor(parent, subWorldTexture) {

--- a/packages/troika-examples/instanceable/InstanceableSphere.js
+++ b/packages/troika-examples/instanceable/InstanceableSphere.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshPhongMaterial,
   Color,
@@ -11,7 +11,7 @@ import {
 
 
 // Common shared geometry
-const geometry = new SphereBufferGeometry(1)
+const geometry = new SphereGeometry(1)
 
 // Common shared material, declaring the diffuse color as an instanceable uniform
 let material = new MeshPhongMaterial()

--- a/packages/troika-examples/instanceable/InstanceableSphereNoMatrix.js
+++ b/packages/troika-examples/instanceable/InstanceableSphereNoMatrix.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshPhongMaterial,
   Color,
@@ -14,7 +14,7 @@ import {
 
 
 // Common shared geometry
-const geometry = new SphereBufferGeometry(1)
+const geometry = new SphereGeometry(1)
 
 // Common shared material, implementing a custom `radius` uniform to use in place of
 // scaling the matrix, and declaring that and the diffuse color as instanceable uniforms.

--- a/packages/troika-examples/instanceable/NonInstanceableSphere.js
+++ b/packages/troika-examples/instanceable/NonInstanceableSphere.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshPhongMaterial, Color
 } from 'three'
@@ -9,7 +9,7 @@ import {
 
 
 // Common shared geometry
-const geometry = new SphereBufferGeometry(1)
+const geometry = new SphereGeometry(1)
 
 class NonInstanceableSphere extends Object3DFacade {
   initThreeObject() {

--- a/packages/troika-examples/lod/Sphere.js
+++ b/packages/troika-examples/lod/Sphere.js
@@ -1,5 +1,5 @@
 import {
-  SphereBufferGeometry,
+  SphereGeometry,
   Mesh,
   MeshPhongMaterial
 } from 'three'
@@ -18,7 +18,7 @@ for (let i = 0; i < LOD_COUNT; i++) {
   let segments = Math.round(MAX_SEGMENTS - i * (MAX_SEGMENTS - MIN_SEGMENTS) / (LOD_COUNT - 1))
   LOD_GEOMETRIES.push({
     distance: i * MAX_DISTANCE / (LOD_COUNT - 1),
-    geometry: new SphereBufferGeometry(1, segments, segments)
+    geometry: new SphereGeometry(1, segments, segments)
   })
 }
 

--- a/packages/troika-examples/package.json
+++ b/packages/troika-examples/package.json
@@ -21,7 +21,7 @@
     "react": "^16.5.2",
     "react-dat-gui": "^4.0.0",
     "react-dom": "^16.5.2",
-    "three": "^0.128.0",
+    "three": "^0.125.0",
     "three-instanced-uniforms-mesh": "^0.46.0",
     "three-line-2d": "^1.1.6",
     "troika-2d": "^0.46.0",

--- a/packages/troika-examples/shader-anim/Cube.js
+++ b/packages/troika-examples/shader-anim/Cube.js
@@ -1,4 +1,4 @@
-import {ShaderMaterial, Mesh, BoxBufferGeometry, TextureLoader, RepeatWrapping} from 'three'
+import {ShaderMaterial, Mesh, BoxGeometry, TextureLoader, RepeatWrapping} from 'three'
 import {Object3DFacade} from 'troika-3d'
 
 
@@ -59,7 +59,7 @@ const waterUniforms = {
 class Cube extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      new BoxBufferGeometry(100, 100, 100),
+      new BoxGeometry(100, 100, 100),
       new ShaderMaterial({
         uniforms: lavaUniforms,
         vertexShader: vertexShader,

--- a/packages/troika-examples/text-rtl/TextExample.jsx
+++ b/packages/troika-examples/text-rtl/TextExample.jsx
@@ -6,7 +6,7 @@ import {
   MeshBasicMaterial,
   MeshStandardMaterial,
   TextureLoader,
-  PlaneBufferGeometry,
+  PlaneGeometry,
   Mesh,
   Color,
   DoubleSide
@@ -418,7 +418,7 @@ class TextExample extends React.Component {
 class ShadowSurface extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      new PlaneBufferGeometry(),
+      new PlaneGeometry(),
       new MeshStandardMaterial({
         color: 0x333333,
         roughness: 0.8,

--- a/packages/troika-examples/text/TextExample.jsx
+++ b/packages/troika-examples/text/TextExample.jsx
@@ -6,7 +6,7 @@ import {
   MeshBasicMaterial,
   MeshStandardMaterial,
   TextureLoader,
-  PlaneBufferGeometry,
+  PlaneGeometry,
   Mesh,
   Color,
   DoubleSide
@@ -388,7 +388,7 @@ class TextExample extends React.Component {
 class ShadowSurface extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      new PlaneBufferGeometry(),
+      new PlaneGeometry(),
       new MeshStandardMaterial({
         color: 0x333333,
         roughness: 0.8,

--- a/packages/troika-examples/ui/CubeOfCubes.js
+++ b/packages/troika-examples/ui/CubeOfCubes.js
@@ -1,12 +1,12 @@
 import { ListFacade } from 'troika-core'
 import { Group3DFacade, Instanceable3DFacade } from 'troika-3d'
 import { extendAsFlexNode } from 'troika-3d-ui'
-import { BoxBufferGeometry, Color, Mesh, MeshStandardMaterial } from 'three'
+import { BoxGeometry, Color, Mesh, MeshStandardMaterial } from 'three'
 
 
 const cubeMaterial = new MeshStandardMaterial({roughness: 0.7, metalness: 0.7})
 const cubeMesh = new Mesh(
-  new BoxBufferGeometry(1, 1, 1),
+  new BoxGeometry(1, 1, 1),
   cubeMaterial
 )
 class Cube extends Instanceable3DFacade {

--- a/packages/troika-examples/ui/FlexboxGlobe.js
+++ b/packages/troika-examples/ui/FlexboxGlobe.js
@@ -1,12 +1,12 @@
 import { Object3DFacade } from 'troika-3d'
 import { extendAsFlexNode } from 'troika-3d-ui'
-import { Mesh, MeshStandardMaterial, SphereBufferGeometry, TextureLoader } from 'three'
+import { Mesh, MeshStandardMaterial, SphereGeometry, TextureLoader } from 'three'
 
 
 class FlexboxGlobe extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      new SphereBufferGeometry(0.5, 64, 64),
+      new SphereGeometry(0.5, 64, 64),
       new MeshStandardMaterial({
         map: new TextureLoader().load('globe/texture_day.jpg'),
         roughness: 0.5,

--- a/packages/troika-examples/ui2/ColorCubes.js
+++ b/packages/troika-examples/ui2/ColorCubes.js
@@ -1,12 +1,12 @@
 import { ListFacade } from 'troika-core'
 import { Group3DFacade, Instanceable3DFacade } from 'troika-3d'
 import { extendAsFlexNode } from 'troika-3d-ui'
-import { BoxBufferGeometry, Color, Mesh, MeshStandardMaterial } from 'three'
+import { BoxGeometry, Color, Mesh, MeshStandardMaterial } from 'three'
 
 
 const cubeMaterial = new MeshStandardMaterial({roughness: 0.7, metalness: 0.7})
 const cubeMesh = new Mesh(
-  new BoxBufferGeometry(1, 1, 1),
+  new BoxGeometry(1, 1, 1),
   cubeMaterial
 )
 class Cube extends Instanceable3DFacade {

--- a/packages/troika-examples/ui2/FlexboxGlobe.js
+++ b/packages/troika-examples/ui2/FlexboxGlobe.js
@@ -1,6 +1,6 @@
 import { Object3DFacade, Group3DFacade } from 'troika-3d'
 import { extendAsFlexNode } from 'troika-3d-ui'
-import { Mesh, MeshStandardMaterial, SphereBufferGeometry } from 'three'
+import { Mesh, MeshStandardMaterial, SphereGeometry } from 'three'
 
 
 let geom
@@ -9,7 +9,7 @@ let geom
 class Globe extends Object3DFacade {
   initThreeObject() {
     return new Mesh(
-      geom || (geom = new SphereBufferGeometry(0.5, 64, 64)),
+      geom || (geom = new SphereGeometry(0.5, 64, 64)),
       new MeshStandardMaterial({
         roughness: 0.5,
         metalness: 0.5

--- a/packages/troika-three-text/package.json
+++ b/packages/troika-three-text/package.json
@@ -20,7 +20,7 @@
     "webgl-sdf-generator": "1.1.1"
   },
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   },
   "devDependencies": {
     "@fredli74/typr": "0.3.5",

--- a/packages/troika-three-text/src/GlyphsGeometry.js
+++ b/packages/troika-three-text/src/GlyphsGeometry.js
@@ -1,8 +1,8 @@
 import {
   Float32BufferAttribute,
   BufferGeometry,
-  PlaneBufferGeometry,
-  InstancedBufferGeometry,
+  PlaneGeometry,
+  InstancedGeometry,
   InstancedBufferAttribute,
   Sphere,
   Box3,
@@ -20,7 +20,7 @@ const GlyphsGeometry = /*#__PURE__*/(() => {
       // appear as DoubleSide by default. FrontSide/BackSide are emulated using drawRange.
       // We do it this way to avoid the performance hit of two draw calls for DoubleSide materials
       // introduced by Three.js in r130 - see https://github.com/mrdoob/three.js/pull/21967
-      const front = new PlaneBufferGeometry(1, 1, detail, detail)
+      const front = new PlaneGeometry(1, 1, detail, detail)
       const back = front.clone()
       const frontAttrs = front.attributes
       const backAttrs = back.attributes

--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -5,7 +5,7 @@ import {
   Matrix4,
   Mesh,
   MeshBasicMaterial,
-  PlaneBufferGeometry,
+  PlaneGeometry,
   Vector3,
   Vector2,
 } from 'three'
@@ -35,7 +35,7 @@ const Text = /*#__PURE__*/(() => {
 
   let getFlatRaycastMesh = () => {
     const mesh = new Mesh(
-      new PlaneBufferGeometry(1, 1),
+      new PlaneGeometry(1, 1),
       defaultMaterial
     )
     getFlatRaycastMesh = () => mesh
@@ -43,7 +43,7 @@ const Text = /*#__PURE__*/(() => {
   }
   let getCurvedRaycastMesh = () => {
     const mesh = new Mesh(
-      new PlaneBufferGeometry(1, 1, 32, 1),
+      new PlaneGeometry(1, 1, 32, 1),
       defaultMaterial
     )
     getCurvedRaycastMesh = () => mesh

--- a/packages/troika-three-utils/docs/createDerivedMaterial.md
+++ b/packages/troika-three-utils/docs/createDerivedMaterial.md
@@ -18,7 +18,7 @@ Here's a simple example that injects an auto-incrementing `elapsed` uniform hold
 
 ```js
 import { createDerivedMaterial} from 'troika-three-utils'
-import { Mesh, MeshStandardMaterial, PlaneBufferGeometry } from 'three'
+import { Mesh, MeshStandardMaterial, PlaneGeometry } from 'three'
 
 const baseMaterial = new MeshStandardMaterial({color: 0xffcc00})
 const customMaterial = createDerivedMaterial(
@@ -37,7 +37,7 @@ const customMaterial = createDerivedMaterial(
   }
 )
 const mesh = new Mesh(
-  new PlaneBufferGeometry(1, 1, 64, 1),
+  new PlaneGeometry(1, 1, 64, 1),
   customMaterial
 )
 

--- a/packages/troika-three-utils/package.json
+++ b/packages/troika-three-utils/package.json
@@ -14,6 +14,6 @@
   "module": "dist/troika-three-utils.esm.js",
   "module:src": "src/index.js",
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   }
 }

--- a/packages/troika-three-utils/src/BezierMesh.js
+++ b/packages/troika-three-utils/src/BezierMesh.js
@@ -1,4 +1,4 @@
-import { CylinderBufferGeometry, DoubleSide, Mesh, MeshStandardMaterial, Vector2, Vector3 } from 'three'
+import { CylinderGeometry, DoubleSide, Mesh, MeshStandardMaterial, Vector2, Vector3 } from 'three'
 import { createBezierMeshMaterial } from './BezierMeshMaterial.js'
 
 let geometry = null
@@ -36,7 +36,7 @@ const defaultBaseMaterial = /*#__PURE__*/new MeshStandardMaterial({color: 0xffff
 class BezierMesh extends Mesh {
   static getGeometry() {
     return geometry || (geometry =
-      new CylinderBufferGeometry(1, 1, 1, 6, 64).translate(0, 0.5, 0)
+      new CylinderGeometry(1, 1, 1, 6, 64).translate(0, 0.5, 0)
     )
   }
 

--- a/packages/troika-xr/package.json
+++ b/packages/troika-xr/package.json
@@ -20,6 +20,6 @@
     "troika-three-utils": "^0.46.0"
   },
   "peerDependencies": {
-    "three": ">=0.103.0"
+    "three": ">=0.125.0"
   }
 }

--- a/packages/troika-xr/src/facade/CursorFacade.js
+++ b/packages/troika-xr/src/facade/CursorFacade.js
@@ -1,7 +1,7 @@
-import { Mesh, MeshBasicMaterial, SphereBufferGeometry, Vector3, Quaternion } from 'three'
+import { Mesh, MeshBasicMaterial, SphereGeometry, Vector3, Quaternion } from 'three'
 import {Object3DFacade} from 'troika-3d'
 
-const cursorGeom = new SphereBufferGeometry()
+const cursorGeom = new SphereGeometry()
 const cursorMaterial = new MeshBasicMaterial({color: 0xffffff})
 const tempVec3 = new Vector3()
 const tempQuat = new Quaternion()

--- a/packages/troika-xr/src/facade/TargetRayFacade.js
+++ b/packages/troika-xr/src/facade/TargetRayFacade.js
@@ -1,10 +1,10 @@
 import { Object3DFacade, createDerivedMaterial } from 'troika-3d'
 import { copyXRPoseToFacadeProps, TARGET_RAY_RENDERORDER } from '../XRUtils.js'
-import { Group, Mesh, MeshBasicMaterial, CylinderBufferGeometry } from 'three'
+import { Group, Mesh, MeshBasicMaterial, CylinderGeometry } from 'three'
 
 
 let getGeometry = () => {
-  const geometry = new CylinderBufferGeometry(1, 1, 1, 4, 1, false)
+  const geometry = new CylinderGeometry(1, 1, 1, 4, 1, false)
     .translate(0, 0.5, 0)
     .rotateY(Math.PI / 4)
     .rotateX(Math.PI / -2)

--- a/packages/troika-xr/src/facade/grip-models/BasicGrip.js
+++ b/packages/troika-xr/src/facade/grip-models/BasicGrip.js
@@ -1,8 +1,8 @@
 import { Object3DFacade } from 'troika-3d'
-import { Mesh, MeshStandardMaterial, CylinderBufferGeometry } from 'three'
+import { Mesh, MeshStandardMaterial, CylinderGeometry } from 'three'
 
 let getGeometry = () => {
-  const geometry = new CylinderBufferGeometry(0.03, 0.05, 0.1, 8)
+  const geometry = new CylinderGeometry(0.03, 0.05, 0.1, 8)
     .rotateX(Math.PI / -2)
     .translate(0, 0, 0.05)
   getGeometry = () => geometry

--- a/packages/troika-xr/src/facade/teleport/GroundTarget.js
+++ b/packages/troika-xr/src/facade/teleport/GroundTarget.js
@@ -1,4 +1,4 @@
-import { ExtrudeBufferGeometry, MeshLambertMaterial, Path, Shape } from 'three'
+import { ExtrudeGeometry, MeshLambertMaterial, Path, Shape } from 'three'
 import { MeshFacade } from 'troika-3d'
 
 const degreeToRad = Math.PI / 180
@@ -19,7 +19,7 @@ let getMarkerGeometry = function () {
       .lineTo(innerRadius, -innerRadius)
   ]
 
-  const geom = new ExtrudeBufferGeometry(shape, {
+  const geom = new ExtrudeGeometry(shape, {
     curveSegments: 64,
     depth,
     bevelEnabled: false

--- a/packages/troika-xr/src/facade/wrist-mounted-ui/Cog.js
+++ b/packages/troika-xr/src/facade/wrist-mounted-ui/Cog.js
@@ -1,5 +1,5 @@
 import { utils } from 'troika-core'
-import { ExtrudeBufferGeometry, Shape, Path } from 'three'
+import { ExtrudeGeometry, Shape, Path } from 'three'
 import { MeshFacade } from 'troika-3d'
 
 const getCogGeometry = utils.memoize(() => {
@@ -25,7 +25,7 @@ const getCogGeometry = utils.memoize(() => {
   shape.holes.push(
     new Path().absellipse(0, 0, innerRadius, innerRadius, 0, twoPi, false)
   )
-  return new ExtrudeBufferGeometry(shape, {
+  return new ExtrudeGeometry(shape, {
     curveSegments: teeth * 2,
     depth: 0.005,
     bevelEnabled: false

--- a/packages/troika-xr/src/facade/wrist-mounted-ui/Strap.js
+++ b/packages/troika-xr/src/facade/wrist-mounted-ui/Strap.js
@@ -1,10 +1,10 @@
 import { utils } from 'troika-core'
-import { CylinderBufferGeometry, DoubleSide, Mesh, MeshStandardMaterial } from 'three'
+import { CylinderGeometry, DoubleSide, Mesh, MeshStandardMaterial } from 'three'
 import { Object3DFacade } from 'troika-3d'
 
 
 const getStrapGeometry = utils.memoize(() => {
-  return new CylinderBufferGeometry(
+  return new CylinderGeometry(
     1,
     1,
     1,


### PR DESCRIPTION
Since r125 (https://github.com/mrdoob/three.js/pull/21031), `THREE.PlaneBufferGeometry` etc. were aliased to `THREE.PlaneGeometry` and vice versa with the removal of `THREE.Geometry`. In r144 (https://github.com/mrdoob/three.js/pull/24352), `THREE.PlaneBufferGeometry` is deprecated and slated for removal in r154 in favor of `THREE.PlaneGeometry` (they were effectively renamed).

This is a breaking change and will bump the minimum supported version of three to r125 in all packages that use built-in geometry.