### PR TITLE
type files for troika-three-text

### DIFF
--- a/packages/troika-three-text/index.ds.ts
+++ b/packages/troika-three-text/index.ds.ts
@@ -1,0 +1,10 @@
+
+export * from './libs/typr.factory'
+export * from './libs/woff2otf.factory'
+export * from './src/FontParser'
+export * from './src/GlyphsGeometry'
+export * from './src/SDFGenerator'
+export * from './src/text'
+export * from './src/TextBuilder'
+export * from './src/TextDerivedMaterial'
+export * from './src/Typesetter'

--- a/packages/troika-three-text/libs/typr.factory.d.ts
+++ b/packages/troika-three-text/libs/typr.factory.d.ts
@@ -1,0 +1,5 @@
+/*!
+Custom build of Typr.ts (https://github.com/fredli74/Typr.ts) for use in Troika text rendering.
+Original MIT license applies: https://github.com/fredli74/Typr.ts/blob/master/LICENSE
+*/
+export default function _default(): any;

--- a/packages/troika-three-text/libs/woff2otf.factory.d.ts
+++ b/packages/troika-three-text/libs/woff2otf.factory.d.ts
@@ -1,0 +1,8 @@
+/*!
+Custom bundle of woff2otf (https://github.com/arty-name/woff2otf) with fflate
+(https://github.com/101arrowz/fflate) for use in Troika text rendering.
+Original licenses apply:
+- fflate: https://github.com/101arrowz/fflate/blob/master/LICENSE (MIT)
+- woff2otf.js: https://github.com/arty-name/woff2otf/blob/master/woff2otf.js (Apache2)
+*/
+export default function _default(): any;

--- a/packages/troika-three-text/package.json
+++ b/packages/troika-three-text/package.json
@@ -13,6 +13,7 @@
   "main": "dist/troika-three-text.umd.js",
   "module": "dist/troika-three-text.esm.js",
   "module:src": "src/index.js",
+  "types": "index.ds.ts",
   "dependencies": {
     "bidi-js": "^1.0.2",
     "troika-three-utils": "^0.47.2",

--- a/packages/troika-three-text/src/FontParser.d.ts
+++ b/packages/troika-three-text/src/FontParser.d.ts
@@ -1,0 +1,2 @@
+export default workerModule;
+declare const workerModule: any;

--- a/packages/troika-three-text/src/GlyphsGeometry.d.ts
+++ b/packages/troika-three-text/src/GlyphsGeometry.d.ts
@@ -1,0 +1,81 @@
+import { InstancedBufferGeometry, Vector4 } from 'three'
+
+/**
+@class GlyphsGeometry
+
+A specialized Geometry for rendering a set of text glyphs. Uses InstancedBufferGeometry to
+render the glyphs using GPU instancing of a single quad, rather than constructing a whole
+geometry with vertices, for much smaller attribute arraybuffers according to this math:
+
+  Where N = number of glyphs...
+
+  Instanced:
+  - position: 4 * 3
+  - index: 2 * 3
+  - normal: 4 * 3
+  - uv: 4 * 2
+  - glyph x/y bounds: N * 4
+  - glyph indices: N * 1
+  = 5N + 38
+
+  Non-instanced:
+  - position: N * 4 * 3
+  - index: N * 2 * 3
+  - normal: N * 4 * 3
+  - uv: N * 4 * 2
+  - glyph indices: N * 1
+  = 39N
+
+A downside of this is the rare-but-possible lack of the instanced arrays extension,
+which we could potentially work around with a fallback non-instanced implementation.
+
+*/
+export class GlyphsGeometry extends InstancedBufferGeometry {
+    set detail(arg: any);
+    get detail(): any;
+    set curveRadius(arg: any);
+    get curveRadius(): any;
+    groups: {
+        start: number;
+        count: number;
+        materialIndex: number;
+    }[];
+    boundingSphere: any;
+    boundingBox: any;
+    computeBoundingSphere(): void;
+    computeBoundingBox(): void;
+    setSide(side: any): void;
+    _detail: any;
+    _curveRadius: any;
+    /**
+     * Update the geometry for a new set of glyphs.
+     * @param {Float32Array} glyphBounds - An array holding the planar bounds for all glyphs
+     *        to be rendered, 4 entries for each glyph: x1,x2,y1,y1
+     * @param {Float32Array} glyphAtlasIndices - An array holding the index of each glyph within
+     *        the SDF atlas texture.
+     * @param {Array} blockBounds - An array holding the [minX, minY, maxX, maxY] across all glyphs
+     * @param {Array} [chunkedBounds] - An array of objects describing bounds for each chunk of N
+     *        consecutive glyphs: `{start:N, end:N, rect:[minX, minY, maxX, maxY]}`. This can be
+     *        used with `applyClipRect` to choose an optimized `instanceCount`.
+     * @param {Uint8Array} [glyphColors] - An array holding r,g,b values for each glyph.
+     */
+    updateGlyphs(glyphBounds: Float32Array, glyphAtlasIndices: Float32Array, blockBounds: any[], chunkedBounds?: any[], glyphColors?: Uint8Array): void;
+    _blockBounds: any[];
+    _chunkedBounds: any[];
+    instanceCount: any;
+    _updateBounds(): void;
+    /**
+     * Given a clipping rect, and the chunkedBounds from the last updateGlyphs call, choose the lowest
+     * `instanceCount` that will show all glyphs within the clipped view. This is an optimization
+     * for long blocks of text that are clipped, to skip vertex shader evaluation for glyphs that would
+     * be clipped anyway.
+     *
+     * Note that since `drawElementsInstanced[ANGLE]` only accepts an instance count and not a starting
+     * offset, this optimization becomes less effective as the clipRect moves closer to the end of the
+     * text block. We could fix that by switching from instancing to a full geometry with a drawRange,
+     * but at the expense of much larger attribute buffers (see classdoc above.)
+     *
+     * @param {Vector4} clipRect
+     */
+    applyClipRect(clipRect: Vector4): void;
+}

--- a/packages/troika-three-text/src/SDFGenerator.d.ts
+++ b/packages/troika-three-text/src/SDFGenerator.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Generate an SDF texture image for a single glyph path, placing the result into a webgl canvas at a
+ * given location and channel. Utilizes the webgl-sdf-generator external package for GPU-accelerated SDF
+ * generation when supported.
+ */
+export function generateSDF(width: any, height: any, path: any, viewBox: any, distance: any, exponent: any, canvas: any, x: any, y: any, channel: any, useWebGL?: boolean): any;
+export function warmUpSDFCanvas(canvas: any): void;
+export const resizeWebGLCanvasWithoutClearing: any;

--- a/packages/troika-three-text/src/TextBuilder.d.ts
+++ b/packages/troika-three-text/src/TextBuilder.d.ts
@@ -1,0 +1,184 @@
+import { Texture } from 'three'
+
+/**
+ * ~callback
+ */
+export type getTextRenderInfo = (textRenderInfo: TroikaTextRenderInfo) => any;
+/**
+ * - Format of the result from `getTextRenderInfo`.
+ */
+export type TroikaTextRenderInfo = {
+    /**
+     * - The normalized input arguments to the render call.
+     */
+    parameters: object;
+    /**
+     * - The SDF atlas texture.
+     */
+    sdfTexture: Texture;
+    /**
+     * - The size of each glyph's SDF; see `configureTextBuilder`.
+     */
+    sdfGlyphSize: number;
+    /**
+     * - The exponent used in encoding the SDF's values; see `configureTextBuilder`.
+     */
+    sdfExponent: number;
+    /**
+     * - List of [minX, minY, maxX, maxY] quad bounds for each glyph.
+     */
+    glyphBounds: Float32Array;
+    /**
+     * - List holding each glyph's index in the SDF atlas.
+     */
+    glyphAtlasIndices: Float32Array;
+    /**
+     * - List holding each glyph's [r, g, b] color, if `colorRanges` was supplied.
+     */
+    glyphColors?: Uint8Array;
+    /**
+     * - A list of caret positions for all characters in the string; each is
+     * three elements: the starting X, the ending X, and the bottom Y for the caret.
+     */
+    caretPositions?: Float32Array;
+    /**
+     * - An appropriate height for all selection carets.
+     */
+    caretHeight?: number;
+    /**
+     * - The font's ascender metric.
+     */
+    ascender: number;
+    /**
+     * - The font's descender metric.
+     */
+    descender: number;
+    /**
+     * - The font's cap height metric, based on the height of Latin capital letters.
+     */
+    capHeight: number;
+    /**
+     * - The font's x height metric, based on the height of Latin lowercase letters.
+     */
+    xHeight: number;
+    /**
+     * - The final computed lineHeight measurement.
+     */
+    lineHeight: number;
+    /**
+     * - The y position of the top line's baseline.
+     */
+    topBaseline: number;
+    /**
+     * - The total [minX, minY, maxX, maxY] rect of the whole text block;
+     * this can include extra vertical space beyond the visible glyphs due to lineHeight, and is
+     * equivalent to the dimensions of a block-level text element in CSS.
+     */
+    blockBounds: Array<number>;
+    /**
+     * - The total [minX, minY, maxX, maxY] rect of the whole text block;
+     * unlike `blockBounds` this is tightly wrapped to the visible glyph paths.
+     */
+    visibleBounds: Array<number>;
+    /**
+     * - List of bounding rects for each consecutive set of N glyphs,
+     * in the format `{start:N, end:N, rect:[minX, minY, maxX, maxY]}`.
+     */
+    chunkedBounds: Array<object>;
+    /**
+     * - Timing info for various parts of the rendering logic including SDF
+     * generation, typesetting, etc.
+     */
+    timings: object;
+};
+/**
+ * Customizes the text builder configuration. This must be called prior to the first font processing
+ * request, and applies to all fonts.
+ *
+ * @param {String} config.defaultFontURL - The URL of the default font to use for text processing
+ *                 requests, in case none is specified or the specifiede font fails to load or parse.
+ *                 Defaults to "Roboto Regular" from Google Fonts.
+ * @param {Number} config.sdfGlyphSize - The default size of each glyph's SDF (signed distance field)
+ *                 texture used for rendering. Must be a power-of-two number, and applies to all fonts,
+ *                 but note that this can also be overridden per call to `getTextRenderInfo()`.
+ *                 Larger sizes can improve the quality of glyph rendering by increasing the sharpness
+ *                 of corners and preventing loss of very thin lines, at the expense of memory. Defaults
+ *                 to 64 which is generally a good balance of size and quality.
+ * @param {Number} config.sdfExponent - The exponent used when encoding the SDF values. A higher exponent
+ *                 shifts the encoded 8-bit values to achieve higher precision/accuracy at texels nearer
+ *                 the glyph's path, with lower precision further away. Defaults to 9.
+ * @param {Number} config.sdfMargin - How much space to reserve in the SDF as margin outside the glyph's
+ *                 path, as a percentage of the SDF width. A larger margin increases the quality of
+ *                 extruded glyph outlines, but decreases the precision available for the glyph itself.
+ *                 Defaults to 1/16th of the glyph size.
+ * @param {Number} config.textureWidth - The width of the SDF texture; must be a power of 2. Defaults to
+ *                 2048 which is a safe maximum texture dimension according to the stats at
+ *                 https://webglstats.com/webgl/parameter/MAX_TEXTURE_SIZE and should allow for a
+ *                 reasonably large number of glyphs (default glyph size of 64^2 and safe texture size of
+ *                 2048^2, times 4 channels, allows for 4096 glyphs.) This can be increased if you need to
+ *                 increase the glyph size and/or have an extraordinary number of glyphs.
+ */
+export function configureTextBuilder(config: any): void;
+/**
+ * @typedef {object} TroikaTextRenderInfo - Format of the result from `getTextRenderInfo`.
+ * @property {object} parameters - The normalized input arguments to the render call.
+ * @property {Texture} sdfTexture - The SDF atlas texture.
+ * @property {number} sdfGlyphSize - The size of each glyph's SDF; see `configureTextBuilder`.
+ * @property {number} sdfExponent - The exponent used in encoding the SDF's values; see `configureTextBuilder`.
+ * @property {Float32Array} glyphBounds - List of [minX, minY, maxX, maxY] quad bounds for each glyph.
+ * @property {Float32Array} glyphAtlasIndices - List holding each glyph's index in the SDF atlas.
+ * @property {Uint8Array} [glyphColors] - List holding each glyph's [r, g, b] color, if `colorRanges` was supplied.
+ * @property {Float32Array} [caretPositions] - A list of caret positions for all characters in the string; each is
+ *           three elements: the starting X, the ending X, and the bottom Y for the caret.
+ * @property {number} [caretHeight] - An appropriate height for all selection carets.
+ * @property {number} ascender - The font's ascender metric.
+ * @property {number} descender - The font's descender metric.
+ * @property {number} capHeight - The font's cap height metric, based on the height of Latin capital letters.
+ * @property {number} xHeight - The font's x height metric, based on the height of Latin lowercase letters.
+ * @property {number} lineHeight - The final computed lineHeight measurement.
+ * @property {number} topBaseline - The y position of the top line's baseline.
+ * @property {Array<number>} blockBounds - The total [minX, minY, maxX, maxY] rect of the whole text block;
+ *           this can include extra vertical space beyond the visible glyphs due to lineHeight, and is
+ *           equivalent to the dimensions of a block-level text element in CSS.
+ * @property {Array<number>} visibleBounds - The total [minX, minY, maxX, maxY] rect of the whole text block;
+ *           unlike `blockBounds` this is tightly wrapped to the visible glyph paths.
+ * @property {Array<object>} chunkedBounds - List of bounding rects for each consecutive set of N glyphs,
+ *           in the format `{start:N, end:N, rect:[minX, minY, maxX, maxY]}`.
+ * @property {object} timings - Timing info for various parts of the rendering logic including SDF
+ *           generation, typesetting, etc.
+ * @frozen
+ */
+/**
+ * @callback getTextRenderInfo~callback
+ * @param {TroikaTextRenderInfo} textRenderInfo
+ */
+/**
+ * Main entry point for requesting the data needed to render a text string with given font parameters.
+ * This is an asynchronous call, performing most of the logic in a web worker thread.
+ * @param {object} args
+ * @param {getTextRenderInfo~callback} callback
+ */
+export function getTextRenderInfo(args: object, callback: any): void;
+/**
+ * Preload a given font and optionally pre-generate glyph SDFs for one or more character sequences.
+ * This can be useful to avoid long pauses when first showing text in a scene, by preloading the
+ * needed fonts and glyphs up front along with other assets.
+ *
+ * @param {object} options
+ * @param {string} options.font - URL of the font file to preload. If not given, the default font will
+ *        be loaded.
+ * @param {string|string[]} options.characters - One or more character sequences for which to pre-
+ *        generate glyph SDFs. Note that this will honor ligature substitution, so you may need
+ *        to specify ligature sequences in addition to their individual characters to get all
+ *        possible glyphs, e.g. `["t", "h", "th"]` to get the "t" and "h" glyphs plus the "th" ligature.
+ * @param {number} options.sdfGlyphSize - The size at which to prerender the SDF textures for the
+ *        specified `characters`.
+ * @param {function} callback - A function that will be called when the preloading is complete.
+ */
+export function preloadFont({ font, characters, sdfGlyphSize }: {
+    font: string;
+    characters: string | string[];
+    sdfGlyphSize: number;
+}, callback: Function): void;
+export const typesetterWorkerModule: any;
+export function dumpSDFTextures(): void;

--- a/packages/troika-three-text/src/TextDerivedMaterial.d.ts
+++ b/packages/troika-three-text/src/TextDerivedMaterial.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Create a material for rendering text, derived from a baseMaterial
+ */
+export function createTextDerivedMaterial(baseMaterial: any): any;

--- a/packages/troika-three-text/src/Typesetter.d.ts
+++ b/packages/troika-three-text/src/Typesetter.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Factory function that creates a self-contained environment for processing text typesetting requests.
+ *
+ * It is important that this function has no closure dependencies, so that it can be easily injected
+ * into the source for a Worker without requiring a build step or complex dependency loading. All its
+ * dependencies must be passed in at initialization.
+ *
+ * @param {function} fontParser - a function that accepts an ArrayBuffer of the font data and returns
+ * a standardized structure giving access to the font and its glyphs:
+ *   {
+ *     unitsPerEm: number,
+ *     ascender: number,
+ *     descender: number,
+ *     capHeight: number,
+ *     xHeight: number,
+ *     lineGap: number,
+ *     forEachGlyph(string, fontSize, letterSpacing, callback) {
+ *       //invokes callback for each glyph to render, passing it an object:
+ *       callback({
+ *         index: number,
+ *         advanceWidth: number,
+ *         xMin: number,
+ *         yMin: number,
+ *         xMax: number,
+ *         yMax: number,
+ *         path: string,
+ *         pathCommandCount: number
+ *       })
+ *     }
+ *   }
+ * @param {object} bidi - the bidi.js implementation object
+ * @param {Object} config
+ * @return {Object}
+ */
+export function createTypesetter(fontParser: Function, bidi: object, config: any): any;

--- a/packages/troika-three-text/src/text.d.ts
+++ b/packages/troika-three-text/src/text.d.ts
@@ -1,0 +1,283 @@
+import { Material, Mesh } from 'three'
+
+/**
+ * @class Text
+ *
+ * A ThreeJS Mesh that renders a string of text on a plane in 3D space using signed distance
+ * fields (SDF).
+ */
+export class Text extends Mesh {
+  /**
+   * @member {string} text
+   * The string of text to be rendered.
+   */
+  text: string;
+  /**
+   * @member {number|string} anchorX
+   * Defines the horizontal position in the text block that should line up with the local origin.
+   * Can be specified as a numeric x position in local units, a string percentage of the total
+   * text block width e.g. `'25%'`, or one of the following keyword strings: 'left', 'center',
+   * or 'right'.
+   */
+  anchorX: number;
+  /**
+   * @member {number|string} anchorX
+   * Defines the vertical position in the text block that should line up with the local origin.
+   * Can be specified as a numeric y position in local units (note: down is negative y), a string
+   * percentage of the total text block height e.g. `'25%'`, or one of the following keyword strings:
+   * 'top', 'top-baseline', 'top-cap', 'top-ex', 'middle', 'bottom-baseline', or 'bottom'.
+   */
+  anchorY: number;
+  set curveRadius(arg: any);
+  get curveRadius(): any;
+  /**
+   * @member {string} direction
+   * Sets the base direction for the text. The default value of "auto" will choose a direction based
+   * on the text's content according to the bidi spec. A value of "ltr" or "rtl" will force the direction.
+   */
+  direction: string;
+  /**
+   * @member {string} font
+   * URL of a custom font to be used. Font files can be in .ttf, .otf, or .woff (not .woff2) formats.
+   * Defaults to the Roboto font loaded from Google Fonts.
+   */
+  font: any;
+  /**
+   * @member {number} fontSize
+   * The size at which to render the font in local units; corresponds to the em-box height
+   * of the chosen `font`.
+   */
+  fontSize: number;
+  /**
+   * @member {number} letterSpacing
+   * Sets a uniform adjustment to spacing between letters after kerning is applied. Positive
+   * numbers increase spacing and negative numbers decrease it.
+   */
+  letterSpacing: number;
+  /**
+   * @member {number|string} lineHeight
+   * Sets the height of each line of text, as a multiple of the `fontSize`. Defaults to 'normal'
+   * which chooses a reasonable height based on the chosen font's ascender/descender metrics.
+   */
+  lineHeight: string;
+  /**
+   * @member {number} maxWidth
+   * The maximum width of the text block, above which text may start wrapping according to the
+   * `whiteSpace` and `overflowWrap` properties.
+   */
+  maxWidth: number;
+  /**
+   * @member {string} overflowWrap
+   * Defines how text wraps if the `whiteSpace` property is `normal`. Can be either `'normal'`
+   * to break at whitespace characters, or `'break-word'` to allow breaking within words.
+   * Defaults to `'normal'`.
+   */
+  overflowWrap: string;
+  /**
+   * @member {string} textAlign
+   * The horizontal alignment of each line of text within the overall text bounding box.
+   */
+  textAlign: string;
+  /**
+   * @member {number} textIndent
+   * Indentation for the first character of a line; see CSS `text-indent`.
+   */
+  textIndent: number;
+  /**
+   * @member {string} whiteSpace
+   * Defines whether text should wrap when a line reaches the `maxWidth`. Can
+   * be either `'normal'` (the default), to allow wrapping according to the `overflowWrap` property,
+   * or `'nowrap'` to prevent wrapping. Note that `'normal'` here honors newline characters to
+   * manually break lines, making it behave more like `'pre-wrap'` does in CSS.
+   */
+  whiteSpace: string;
+
+  /**
+   * @member {string|number|THREE.Color} color
+   * This is a shortcut for setting the `color` of the text's material. You can use this
+   * if you don't want to specify a whole custom `material`. Also, if you do use a custom
+   * `material`, this color will only be used for this particuar Text instance, even if
+   * that same material instance is shared across multiple Text objects.
+   */
+  color: any;
+  /**
+   * @member {object|null} colorRanges
+   * WARNING: This API is experimental and may change.
+   * This allows more fine-grained control of colors for individual or ranges of characters,
+   * taking precedence over the material's `color`. Its format is an Object whose keys each
+   * define a starting character index for a range, and whose values are the color for each
+   * range. The color value can be a numeric hex color value, a `THREE.Color` object, or
+   * any of the strings accepted by `THREE.Color`.
+   */
+  colorRanges: any;
+  /**
+   * @member {number|string} outlineWidth
+   * WARNING: This API is experimental and may change.
+   * The width of an outline/halo to be drawn around each text glyph using the `outlineColor` and `outlineOpacity`.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g.
+   * `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`, which means
+   * no outline will be drawn unless an `outlineOffsetX/Y` or `outlineBlur` is set.
+   */
+  outlineWidth: number;
+  /**
+   * @member {string|number|THREE.Color} outlineColor
+   * WARNING: This API is experimental and may change.
+   * The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
+   * Defaults to black.
+   */
+  outlineColor: number;
+  /**
+   * @member {number} outlineOpacity
+   * WARNING: This API is experimental and may change.
+   * The opacity of the outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
+   * Defaults to `1`.
+   */
+  outlineOpacity: number;
+  /**
+   * @member {number|string} outlineBlur
+   * WARNING: This API is experimental and may change.
+   * A blur radius applied to the outer edge of the text's outline. If the `outlineWidth` is
+   * zero, the blur will be applied at the glyph edge, like CSS's `text-shadow` blur radius.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g.
+   * `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  outlineBlur: number;
+  /**
+   * @member {number|string} outlineOffsetX
+   * WARNING: This API is experimental and may change.
+   * A horizontal offset for the text outline.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  outlineOffsetX: number;
+  /**
+   * @member {number|string} outlineOffsetY
+   * WARNING: This API is experimental and may change.
+   * A vertical offset for the text outline.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  outlineOffsetY: number;
+  /**
+   * @member {number|string} strokeWidth
+   * WARNING: This API is experimental and may change.
+   * The width of an inner stroke drawn inside each text glyph using the `strokeColor` and `strokeOpacity`.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  strokeWidth: number;
+  /**
+   * @member {string|number|THREE.Color} strokeColor
+   * WARNING: This API is experimental and may change.
+   * The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
+   */
+  strokeColor: number;
+  /**
+   * @member {number} strokeOpacity
+   * WARNING: This API is experimental and may change.
+   * The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
+   */
+  strokeOpacity: number;
+  /**
+   * @member {number} fillOpacity
+   * WARNING: This API is experimental and may change.
+   * The opacity of the glyph's fill from 0 to 1. This behaves like the material's `opacity` but allows
+   * giving the fill a different opacity than the `strokeOpacity`. A fillOpacity of `0` makes the
+   * interior of the glyph invisible, leaving just the `strokeWidth`. Defaults to `1`.
+   */
+  fillOpacity: number;
+  /**
+   * @member {number} depthOffset
+   * This is a shortcut for setting the material's `polygonOffset` and related properties,
+   * which can be useful in preventing z-fighting when this text is laid on top of another
+   * plane in the scene. Positive numbers are further from the camera, negatives closer.
+   */
+  depthOffset: number;
+  /**
+   * @member {Array<number>} clipRect
+   * If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all
+   * pixels will be discarded. This can be used for example to clip overflowing text when
+   * `whiteSpace='nowrap'`.
+   */
+  clipRect: any;
+  /**
+   * @member {string} orientation
+   * Defines the axis plane on which the text should be laid out when the mesh has no extra
+   * rotation transform. It is specified as a string with two axes: the horizontal axis with
+   * positive pointing right, and the vertical axis with positive pointing up. By default this
+   * is '+x+y', meaning the text sits on the xy plane with the text's top toward positive y
+   * and facing positive z. A value of '+x-z' would place it on the xz plane with the text's
+   * top toward negative z and facing positive y.
+   */
+  orientation: string;
+  set glyphGeometryDetail(arg: any);
+  get glyphGeometryDetail(): any;
+  /**
+   * @member {number|null} sdfGlyphSize
+   * The size of each glyph's SDF (signed distance field) used for rendering. This must be a
+   * power-of-two number. Defaults to 64 which is generally a good balance of size and quality
+   * for most fonts. Larger sizes can improve the quality of glyph rendering by increasing
+   * the sharpness of corners and preventing loss of very thin lines, at the expense of
+   * increased memory footprint and longer SDF generation time.
+   */
+  sdfGlyphSize: any;
+  /**
+   * @member {boolean} gpuAccelerateSDF
+   * When `true`, the SDF generation process will be GPU-accelerated with WebGL when possible,
+   * making it much faster especially for complex glyphs, and falling back to a JavaScript version
+   * executed in web workers when support isn't available. It should automatically detect support,
+   * but it's still somewhat experimental, so you can set it to `false` to force it to use the JS
+   * version if you encounter issues with it.
+   */
+  gpuAccelerateSDF: boolean;
+  debugSDF: boolean;
+  /**
+   * Updates the text rendering according to the current text-related configuration properties.
+   * This is an async process, so you can pass in a callback function to be executed when it
+   * finishes.
+   * @param {function} [callback]
+   */
+  sync(callback?: Function): void;
+  _needsSync: boolean;
+  _queuedSyncs: any[];
+  _isSyncing: boolean;
+  _textRenderInfo: any;
+
+  /**
+   * Shortcut to dispose the geometry specific to this instance.
+   * Note: we don't also dispose the derived material here because if anything else is
+   * sharing the same base material it will result in a pause next frame as the program
+   * is recompiled. Instead users can dispose the base material manually, like normal,
+   * and we'll also dispose the derived material at that time.
+   */
+  dispose(): void;
+  /**
+   * @property {TroikaTextRenderInfo|null} textRenderInfo
+   * @readonly
+   * The current processed rendering data for this TextMesh, returned by the TextBuilder after
+   * a `sync()` call. This will be `null` initially, and may be stale for a short period until
+   * the asynchrous `sync()` process completes.
+   */
+  get textRenderInfo(): any;
+  _defaultMaterial: any;
+  _derivedMaterial: any;
+  _baseMaterial: any;
+  _prepareForRender(material: any): void;
+  _parsePercent(value: any): any;
+  /**
+   * Translate a point in local space to an x/y in the text plane.
+   */
+  localPositionToTextCoords(position: any, target?: any): any;
+  /**
+   * Translate a point in world space to an x/y in the text plane.
+   */
+  worldPositionToTextCoords(position: any, target?: any): any;
+  /**
+   * @override Custom raycasting to test against the whole text block's max rectangular bounds
+   * TODO is there any reason to make this more granular, like within individual line or glyph rects?
+   */
+  override raycast(raycaster: any, intersects: any): void;
+  copy(source: any): this;
+  geometry: any;
+  clone(): any;
+}


### PR DESCRIPTION
Based on info in [Typescript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html), started with this comment

```
npx -p typescript tsc src/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir types
```

Pulled generated files into test project and tweaked until compile errors were fixed.

