### PR TITLE
Default `Text.material.toneMapped` to `false`

### DIFF
--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -17,7 +17,8 @@ import { getTextRenderInfo } from './TextBuilder.js'
 const defaultMaterial = /*#__PURE__*/ new MeshBasicMaterial({
   color: 0xffffff,
   side: DoubleSide,
-  transparent: true
+  transparent: true,
+  toneMapped: false
 })
 const defaultStrokeColor = 0x808080
 


### PR DESCRIPTION
three.js sets `toneMapping` to `NoToneMapping` by default, however react-three-fiber sets it it to `ACESFilmicToneMapping` by default, which produces some modified colors for `Text`s.

It would be nice to disable tone mapping by default for `Text`s since it probably doesn't make sense to apply tone mapping to text.