### PR TITLE
Change types for createDerivedMaterial to be optional

### DIFF
--- a/packages/troika-three-utils/src/DerivedMaterial.js
+++ b/packages/troika-three-utils/src/DerivedMaterial.js
@@ -36,41 +36,42 @@ let materialInstanceId = 1e10
  * @param {THREE.Material} baseMaterial - the original material to derive from
  *
  * @param {Object} options - How the base material should be modified.
- * @param {Object} options.defines - Custom `defines` for the material
- * @param {Object} options.extensions - Custom `extensions` for the material, e.g. `{derivatives: true}`
- * @param {Object} options.uniforms - Custom `uniforms` for use in the modified shader. These can
+ * @param {Object=} options.defines - Custom `defines` for the material
+ * @param {Object=} options.extensions - Custom `extensions` for the material, e.g. `{derivatives: true}`
+ * @param {Object=} options.uniforms - Custom `uniforms` for use in the modified shader. These can
  *        be accessed and manipulated via the resulting material's `uniforms` property, just like
  *        in a ShaderMaterial. You do not need to repeat the base material's own uniforms here.
- * @param {String} options.timeUniform - If specified, a uniform of this name will be injected into
+ * @param {String=} options.timeUniform - If specified, a uniform of this name will be injected into
  *        both shaders, and it will automatically be updated on each render frame with a number of
  *        elapsed milliseconds. The "zero" epoch time is not significant so don't rely on this as a
  *        true calendar time.
- * @param {String} options.vertexDefs - Custom GLSL code to inject into the vertex shader's top-level
+ * @param {String=} options.vertexDefs - Custom GLSL code to inject into the vertex shader's top-level
  *        definitions, above the `void main()` function.
- * @param {String} options.vertexMainIntro - Custom GLSL code to inject at the top of the vertex
+ * @param {String=} options.vertexMainIntro - Custom GLSL code to inject at the top of the vertex
  *        shader's `void main` function.
- * @param {String} options.vertexMainOutro - Custom GLSL code to inject at the end of the vertex
+ * @param {String=} options.vertexMainOutro - Custom GLSL code to inject at the end of the vertex
  *        shader's `void main` function.
- * @param {String} options.vertexTransform - Custom GLSL code to manipulate the `position`, `normal`,
+ * @param {String=} options.vertexTransform - Custom GLSL code to manipulate the `position`, `normal`,
  *        and/or `uv` vertex attributes. This code will be wrapped within a standalone function with
  *        those attributes exposed by their normal names as read/write values.
- * @param {String} options.fragmentDefs - Custom GLSL code to inject into the fragment shader's top-level
+ * @param {String=} options.fragmentDefs - Custom GLSL code to inject into the fragment shader's top-level
  *        definitions, above the `void main()` function.
- * @param {String} options.fragmentMainIntro - Custom GLSL code to inject at the top of the fragment
+ * @param {String=} options.fragmentMainIntro - Custom GLSL code to inject at the top of the fragment
  *        shader's `void main` function.
- * @param {String} options.fragmentMainOutro - Custom GLSL code to inject at the end of the fragment
+ * @param {String=} options.fragmentMainOutro - Custom GLSL code to inject at the end of the fragment
  *        shader's `void main` function. You can manipulate `gl_FragColor` here but keep in mind it goes
  *        after any of ThreeJS's color postprocessing shader chunks (tonemapping, fog, etc.), so if you
  *        want those to apply to your changes use `fragmentColorTransform` instead.
- * @param {String} options.fragmentColorTransform - Custom GLSL code to manipulate the `gl_FragColor`
+ * @param {String=} options.fragmentColorTransform - Custom GLSL code to manipulate the `gl_FragColor`
  *        output value. Will be injected near the end of the `void main` function, but before any
  *        of ThreeJS's color postprocessing shader chunks (tonemapping, fog, etc.), and before the
  *        `fragmentMainOutro`.
- * @param {function<{vertexShader,fragmentShader}>:{vertexShader,fragmentShader}} options.customRewriter - A function
+ * @param {function({fragmentShader: string, vertexShader:string}): 
+ *        {fragmentShader: string, vertexShader:string}} options.customRewriter - A function
  *        for performing custom rewrites of the full shader code. Useful if you need to do something
  *        special that's not covered by the other builtin options. This function will be executed before
  *        any other transforms are applied.
- * @param {boolean} options.chained - Set to `true` to prototype-chain the derived material to the base
+ * @param {boolean=} options.chained - Set to `true` to prototype-chain the derived material to the base
  *        material, rather than the default behavior of copying it. This allows the derived material to
  *        automatically pick up changes made to the base material and its properties. This can be useful
  *        where the derived material is hidden from the user as an implementation detail, allowing them


### PR DESCRIPTION
I ran into type issues when I was working with createDerivedmaterial and I found a relatively simple solution for them. I'm not very accustomed to using JSDoc, so let me know if I'm horribly wrong here but it looks good for me. Here's a quick rundown:

In a fresh Typescript (sveltekit) project I get the classic "Could not find a declaration file for module 'troika-three-utils'", despite it being type with JSDocs. I found that adding `"maxNodeModuleJsDepth": 1` in tsconfig fixes the issue. (Could be worth adding to docs, I didn't do that yet)

With that out of the way, I am now getting type checking and autocomplete but all of the defined types for `createDerivedMaterial` options are required. I found that adding `=` after the specified type makes it optional.
https://jsdoc.app/tags-param#optional-parameters-and-default-values

```js
  /**
   * @param {Object} options.defines - <<< THIS IS REQUIRED
   * @param {Object=} options.extensions -  <<< THIS IS OPTIONAL
   */
   ```
   
As a result, after adding `"maxNodeModuleJsDepth": 1` to tsconfig and applying my proposed changes I get correct types

![Code_iNNKkmLagr](https://github.com/protectwise/troika/assets/16734228/f3c86777-2566-48c5-913c-171b3771c72f)