### PR TITLE
fix(troika-three-utils): add support for `colorspace_fragment` introduced in Three r154

### DIFF
--- a/packages/troika-three-utils/src/DerivedMaterial.js
+++ b/packages/troika-three-utils/src/DerivedMaterial.js
@@ -304,7 +304,7 @@ function upgradeShaders(material, {vertexShader, fragmentShader}, options, key) 
     // this particular derivation doesn't have a fragmentColorTransform, other derivations may,
     // so we still mark them.
     fragmentShader = fragmentShader.replace(
-      /^[ \t]*#include <((?:tonemapping|encodings|fog|premultiplied_alpha|dithering)_fragment)>/gm,
+      /^[ \t]*#include <((?:tonemapping|encodings|colorspace|fog|premultiplied_alpha|dithering)_fragment)>/gm,
       '\n//!BEGIN_POST_CHUNK $1\n$&\n//!END_POST_CHUNK\n'
     )
     fragmentShader = expandShaderIncludes(fragmentShader)


### PR DESCRIPTION
This PR fixes #324.
Color space is applied to a text color using custom shaders in `upgradeShaders()` ([troika-three-utils/src/DerivedMaterial.js#L306](https://github.com/protectwise/troika/blob/d23f360c4316fa782d351151062ea3b0c2629ca1/packages/troika-three-utils/src/DerivedMaterial.js#L306)) through injecting custom shader code into the `encodings_fragment` shader. The shader has been renamed `colorspace_fragment` in https://github.com/mrdoob/three.js/pull/26206 since Three **r154**.  Since the pre-r154 fragment shader name is kept in the list, this PR shouldn't break compatibility with Three versions before r154.
