### PR TITLE
feat(troika-three-text): Add a property to toggle ligatures

### DIFF
--- a/packages/troika-3d-text/src/facade/Text3DFacade.js
+++ b/packages/troika-3d-text/src/facade/Text3DFacade.js
@@ -19,6 +19,7 @@ export const TEXT_MESH_PROPS = [
   'textAlign',
   'textIndent',
   'whiteSpace',
+  'enableLigatures',
   'material',
   'color',
   'colorRanges',

--- a/packages/troika-examples/text/TextExample.jsx
+++ b/packages/troika-examples/text/TextExample.jsx
@@ -116,6 +116,7 @@ class TextExample extends React.Component {
       textScale: 1,
       lineHeight: 1.15,
       letterSpacing: 0,
+      enableLigatures: true,
       maxWidth: 2, //2m
       textAlign: 'justify',
       textIndent: 0,
@@ -217,6 +218,7 @@ class TextExample extends React.Component {
               textIndent: state.textIndent,
               lineHeight: state.lineHeight,
               letterSpacing: state.letterSpacing,
+              enableLigatures: state.enableLigatures,
               anchorX: state.anchorX,
               anchorY: state.anchorY,
               selectable: state.selectable,
@@ -342,6 +344,7 @@ class TextExample extends React.Component {
                 {type: 'number', path: "maxWidth", min: 1, max: 5, step: 0.01},
                 {type: 'number', path: "lineHeight", min: 1, max: 2, step: 0.01},
                 {type: 'number', path: "letterSpacing", min: -0.1, max: 0.5, step: 0.01},
+                {type: 'boolean', path: "enableLigatures", label: "Ligatures"},
                 {type: 'number', path: "fillOpacity", min: 0, max: 1, step: 0.0001},
                 {type: 'number', path: "curveRadius", min: -5, max: 5, step: 0.001},
 

--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -66,6 +66,7 @@ const SYNCABLE_PROPS = [
   'textAlign',
   'textIndent',
   'whiteSpace',
+  'enableLigatures',
   'anchorX',
   'anchorY',
   'colorRanges',
@@ -221,6 +222,13 @@ class Text extends Mesh {
      * manually break lines, making it behave more like `'pre-wrap'` does in CSS.
      */
     this.whiteSpace = 'normal'
+
+    /**
+     * @member {boolean} enableLigatures
+     * Toggles ligature substitution.
+     * Defaults to true.
+     */
+    this.enableLigatures = true
 
 
     // === Presentation properties: === //
@@ -432,6 +440,7 @@ class Text extends Mesh {
           textAlign: this.textAlign,
           textIndent: this.textIndent,
           whiteSpace: this.whiteSpace,
+          enableLigatures: this.enableLigatures,
           overflowWrap: this.overflowWrap,
           anchorX: this.anchorX,
           anchorY: this.anchorY,

--- a/packages/troika-three-text/src/Typesetter.js
+++ b/packages/troika-three-text/src/Typesetter.js
@@ -21,6 +21,7 @@
  * @property {string} [textAlign='left']
  * @property {number} [textIndent=0]
  * @property {'normal'|'nowrap'} [whiteSpace='normal']
+ * @property {boolean} [enableLigatures=true]
  * @property {'normal'|'break-word'} [overflowWrap='normal']
  * @property {AnchorXValue} [anchorX=0]
  * @property {AnchorYValue} [anchorY=0]
@@ -156,6 +157,7 @@ export function createTypesetter(resolveFonts, bidi) {
       textAlign='left',
       textIndent=0,
       whiteSpace='normal',
+      enableLigatures=true,
       overflowWrap='normal',
       anchorX = 0,
       anchorY = 0,
@@ -256,7 +258,7 @@ export function createTypesetter(resolveFonts, bidi) {
 
         const runText = text.slice(run.start, run.end + 1)
         let prevGlyphX, prevGlyphObj
-        fontObj.forEachGlyph(runText, fontSize, letterSpacing, (glyphObj, glyphX, glyphY, charIndex) => {
+        fontObj.forEachGlyph(runText, fontSize, letterSpacing, enableLigatures, (glyphObj, glyphX, glyphY, charIndex) => {
           glyphX += prevRunEndX
           charIndex += run.start
           prevGlyphX = glyphX
@@ -503,7 +505,7 @@ export function createTypesetter(resolveFonts, bidi) {
               if (rtl) {
                 const mirrored = bidi.getMirroredCharacter(text[glyphInfo.charIndex])
                 if (mirrored) {
-                  glyphInfo.fontData.fontObj.forEachGlyph(mirrored, 0, 0, setGlyphObj)
+                  glyphInfo.fontData.fontObj.forEachGlyph(mirrored, 0, 0, enableLigatures, setGlyphObj)
                 }
               }
 


### PR DESCRIPTION
**Changes:**
- Added a `enableLigatures` property to `Text` to toggle ligature substitution.
- Ligature substitution is also automatically disabled when letter spacing is not zero.

This PR fixes #349 