### PR TITLE
Add .js to imports in BatchedText

### DIFF
--- a/packages/troika-three-text/src/BatchedText.js
+++ b/packages/troika-three-text/src/BatchedText.js
@@ -1,8 +1,8 @@
 import { Text } from "./Text.js";
 import { DataTexture, FloatType, RGBAFormat, Vector2, Box3, Color, DynamicDrawUsage } from "three";
-import { glyphBoundsAttrName, glyphIndexAttrName } from "./GlyphsGeometry";
+import { glyphBoundsAttrName, glyphIndexAttrName } from "./GlyphsGeometry.js";
 import { createDerivedMaterial } from "troika-three-utils";
-import { createTextDerivedMaterial } from "./TextDerivedMaterial";
+import { createTextDerivedMaterial } from "./TextDerivedMaterial.js";
 
 const syncStartEvent = { type: "syncstart" };
 const syncCompleteEvent = { type: "synccomplete" };


### PR DESCRIPTION
This allows me to directly import using importmaps in my projects instead of using a bundler.
For example:
```html
      <script type="importmap">
      {
        "imports": {
          "three": "https://cdn.jsdelivr.net/npm/three@0.174.0/build/three.module.js",
          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.174.0/examples/jsm/",
          "troika-three-text": "https://rawcdn.githack.com/dli7319/troika/refs/heads/cdn/packages/troika-three-text/src/index.js",
          "troika-three-utils": "https://rawcdn.githack.com/protectwise/troika/refs/tags/v0.52.3/packages/troika-three-utils/src/index.js",
          "troika-worker-utils": "https://rawcdn.githack.com/protectwise/troika/refs/tags/v0.52.3/packages/troika-worker-utils/src/index.js",
          "bidi-js": "https://esm.sh/bidi-js@%5E1.0.2?target=es2022",
          "webgl-sdf-generator": "https://esm.sh/webgl-sdf-generator@1.1.1/es2022/webgl-sdf-generator.mjs"
        }
      }
      </script>
```