### PR TITLE
Prevent rendering Text while GlyphsGeometry is not ready

### DIFF
--- a/packages/troika-three-text/src/GlyphsGeometry.js
+++ b/packages/troika-three-text/src/GlyphsGeometry.js
@@ -67,6 +67,10 @@ class GlyphsGeometry extends InstancedBufferGeometry {
     // Preallocate empty bounding objects
     this.boundingSphere = new Sphere()
     this.boundingBox = new Box3()
+
+    // Prevent rendering while we don't have any glyphs
+    this.instanceCount = 0
+    this.setDrawRange(0, 0)
   }
 
   computeBoundingSphere () {
@@ -124,6 +128,7 @@ class GlyphsGeometry extends InstancedBufferGeometry {
     this._blockBounds = blockBounds
     this._chunkedBounds = chunkedBounds
     this.instanceCount = glyphAtlasIndices.length
+    this.setDrawRange(0, Infinity)
     this._updateBounds()
   }
 


### PR DESCRIPTION
Currently, because of three.js `src\renderers\WebGLRenderer.js` logic and the default instanceCount of InstancedBufferGeometry being Infinity, the renderer will attempt to render an infinite number of triangle while `GlyphsGeometry` wait for its first call to updateGlyphs.

This results in three.js WebGL.info displaying "Infinity" next to the triangle counter.

https://github.com/user-attachments/assets/1757f6f9-e1bb-4e8d-bdda-4bf6a2fd29f8

This also cause WebGLRenderer to try to make a render call with something that isn't ready, calling different binding etc as there is no early exit in the current state.

In this PR by setting instanceCount to 0 and drawRange to (0, 0) in the constructor, it'll guarantee that three.js WebGLRenderer early exit the render call for the current Text.
It should slighly improve the time to first render of the Text even though it's already barely noticeable while also preventing this confusing "Infinity" in the webgl infos whenever a new Text is added.

