### PR TITLE
three-instanced-uniforms-mesh: add an ability to make varying non-interpolated (flat)

### DIFF
--- a/packages/three-instanced-uniforms-mesh/README.md
+++ b/packages/three-instanced-uniforms-mesh/README.md
@@ -3,7 +3,7 @@
 This package provides a `InstancedUniformsMesh` class which extends Three.js's [`InstancedMesh`](https://threejs.org/docs/#api/en/objects/InstancedMesh) to allow its material's shader uniforms to be set individually per instance. It behaves just like `InstancedMesh` but exposes a new method:
 
 ```js
-mesh.setUniformAt(uniformName, instanceIndex, value)
+mesh.setUniformAt(uniformName, instanceIndex, value, uniformOptions?)
 ```
 
 When you call `setUniformAt`, the geometry and the material's shaders will be automatically upgraded behind the scenes to turn that uniform into an instanced buffer attribute, filling in the other indices with the uniform's default value. You can do this for any uniform of type `float`, `vec2`, `vec3`, or `vec4`. It works both for built-in Three.js materials and also for any custom ShaderMaterial.
@@ -31,6 +31,13 @@ While this is obviously useful for Three.js's built in materials, it _really_ sh
 
 > Note: Calling `setUniformAt` automatically marks the underlying buffer attributes for upload, so unlike [`setMatrixAt`](https://threejs.org/docs/#api/en/objects/InstancedMesh.setMatrixAt) or [`setColorAt`](https://threejs.org/docs/#api/en/objects/InstancedMesh.setColorAt) you don't need to set `needsUpdate` manually.
 
+
+### Uniform options
+
+You can specify uniform options when call `setUniformAt` for the first time. You don't need to pass them everytime. 
+Default options are:
+* `interpolate: true`
+  should attribute be interpolated. If `false`, value will not be interpolated in fragment shader by marking it as `flat`.
 
 ### Value Types
 

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsDerivedMaterial.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsDerivedMaterial.js
@@ -1,6 +1,6 @@
 import { createDerivedMaterial, getShaderUniformTypes, voidMainRegExp } from 'troika-three-utils'
 
-export function createInstancedUniformsDerivedMaterial (baseMaterial) {
+export function createInstancedUniformsDerivedMaterial(baseMaterial) {
   let _uniforms = new Map()
   let _uniformNamesKey = ''
 
@@ -34,7 +34,7 @@ export function createInstancedUniformsDerivedMaterial (baseMaterial) {
           if (fragType) {
             fragmentShader = fragmentShader.replace(declarationFinder, '')
             fragmentShader = fragmentShader.replace(referenceFinder, varyingName)
-            let varyingDecl = `${ (options.isFlat) ? 'flat' : '' } varying ${fragType} ${varyingName};`
+            let varyingDecl = `${ (options.interpolate === false) ? 'flat' : '' } varying ${fragType} ${varyingName};`
             vertexDeclarations.push(varyingDecl)
             fragmentDeclarations.push(varyingDecl)
             vertexAssignments.push(`${varyingName} = ${attrName};`)
@@ -57,7 +57,7 @@ export function createInstancedUniformsDerivedMaterial (baseMaterial) {
   /**
    * Update the set of uniforms that will be enabled for per-instance values. This
    * can be changed dynamically after instantiation.
-   * @param {Map<string, { isFlat: boolean }>} uniforms
+   * @param {Map<string, { interpolate: boolean }>} uniforms
    */
   derived.setUniforms = function(uniforms) {
     _uniforms = uniforms || new Map()

--- a/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
+++ b/packages/three-instanced-uniforms-mesh/src/InstancedUniformsMesh.js
@@ -6,7 +6,7 @@ export class InstancedUniformsMesh extends InstancedMesh {
   constructor (geometry, material, count) {
     super(geometry, material, count)
     this._maxCount = count;
-    this._instancedUniformNames = [] //treated as immutable
+    this._instancedUniforms = new Map() // Map<uniformName, { isFlat: boolean }>
   }
 
   /*
@@ -50,7 +50,7 @@ export class InstancedUniformsMesh extends InstancedMesh {
         derivedMaterial.dispose()
       })
     }
-    derivedMaterial.setUniformNames(this._instancedUniformNames)
+    derivedMaterial.setUniforms(this._instancedUniforms)
     return derivedMaterial
   }
 
@@ -84,8 +84,9 @@ export class InstancedUniformsMesh extends InstancedMesh {
    * @param {string} name - the name of the shader uniform
    * @param {number} index - the index of the instance to set the value for
    * @param {number|Vector2|Vector3|Vector4|Color|Array|Matrix3|Matrix4|Quaternion} value - the uniform value for this instance
+   * @param {boolean} isFlat - should attribute be marked as flat. If true, value will not be interpolated in fragment shader
    */
-  setUniformAt (name, index, value) {
+  setUniformAt (name, index, value, isFlat = false) {
     const attrs = this.geometry.attributes
     const attrName = `troika_attr_${name}`
     let attr = attrs[attrName]
@@ -99,7 +100,7 @@ export class InstancedUniformsMesh extends InstancedMesh {
           setAttributeValue(attr, i, defaultValue)
         }
       }
-      this._instancedUniformNames = [...this._instancedUniformNames, name]
+      this._instancedUniforms.set(name, { isFlat })
     }
     setAttributeValue(attr, index, value)
     attr.needsUpdate = true
@@ -112,7 +113,7 @@ export class InstancedUniformsMesh extends InstancedMesh {
    */
   unsetUniform (name) {
     this.geometry.deleteAttribute(`troika_attr_${name}`)
-    this._instancedUniformNames = this._instancedUniformNames.filter(n => n !== name)
+    this._instancedUniforms.delete(name)
   }
 }
 


### PR DESCRIPTION
I added an ability to make a varying non-interpolated, "flat".

Usage:
```javascript
mesh.setUniformAt(uniformName, index, value, isFlat);
```

In my case I needed it to add 16 textures to the shader and have an ability to set the texture index.