### PR TITLE
Set and get the srgb colorspace from the output encoding. Due to deprecated outputEncoding

### DIFF
--- a/docs/troika-3d/scenes.md
+++ b/docs/troika-3d/scenes.md
@@ -29,7 +29,9 @@ The `<Canvas3D>` React component is your starting point. This component creates 
 
 - `onBackgroundClick` - A function that will be called when the user clicks the scene's background without hitting an object.
 
-- `outputEncoding` - Sets the Three.js renderer's [`outputEncoding`](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.outputEncoding)
+- `outputEncoding` - Deprecated use outputColorSpace instead. Sets the Three.js renderer's [`outputEncoding`](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.outputEncoding)
+
+- `outputColorSpace` - Sets the Three.js renderer's [`outputColorSpace`](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.outputColorSpace)
 
 - `pixelRatio` - Sets the pixel ratio for the canvas. Defaults to the current screen's reported `window.devicePixelRatio`.
 

--- a/packages/troika-3d/src/facade/World3DFacade.js
+++ b/packages/troika-3d/src/facade/World3DFacade.js
@@ -1,72 +1,120 @@
-import { WorldBaseFacade, utils } from 'troika-core'
-import { WebGLRenderer, Raycaster, Color, Vector2, Vector3, LinearEncoding, NoToneMapping } from 'three'
-import Scene3DFacade from './Scene3DFacade.js'
-import {PerspectiveCamera3DFacade} from './Camera3DFacade.js'
-import {BoundingSphereOctree} from '../BoundingSphereOctree.js'
+import { WorldBaseFacade, utils } from 'troika-core';
+import {
+  WebGLRenderer,
+  Raycaster,
+  Color,
+  Vector2,
+  Vector3,
+  NoToneMapping,
+} from 'three';
+import Scene3DFacade from './Scene3DFacade.js';
+import { PerspectiveCamera3DFacade } from './Camera3DFacade.js';
+import { BoundingSphereOctree } from '../BoundingSphereOctree.js';
 
-const { assign } = utils
-const tmpVec2 = new Vector2()
-const tmpVec3 = new Vector3()
-const raycaster = new Raycaster()
+const { assign } = utils;
+const tmpVec2 = new Vector2();
+const tmpVec3 = new Vector3();
+const raycaster = new Raycaster();
 
+const LinearEncoding = 3000;
+const sRGBEncoding = 3001;
+const SRGBColorSpace = 'srgb';
+const LinearSRGBColorSpace = 'srgb-linear';
 
 class World3DFacade extends WorldBaseFacade {
   constructor(canvas) {
-    super(canvas)
-    this._object3DFacadesById = Object.create(null)
-    this._onBgClick = this._onBgClick.bind(this)
+    super(canvas);
+    this._object3DFacadesById = Object.create(null);
+    this._onBgClick = this._onBgClick.bind(this);
+  }
+
+  /**
+   * Get the output encoding from the srgb color space for backwards compatibility
+   */
+  get outputEncoding() {
+    return this.outputColorSpace === SRGBColorSpace
+      ? sRGBEncoding
+      : LinearEncoding;
+  }
+
+  /**
+   * Set the srgb colorspace from the output encoding for backwards compatibility
+   */
+  set outputEncoding(encoding) {
+    this.outputColorSpace =
+      encoding === sRGBEncoding ? SRGBColorSpace : LinearSRGBColorSpace;
   }
 
   afterUpdate() {
-    let {width, height, antialias, backgroundColor, contextAttributes, _element:canvas} = this
+    let {
+      width,
+      height,
+      antialias,
+      backgroundColor,
+      contextAttributes,
+      _element: canvas,
+    } = this;
 
     // Set up renderer
-    let renderer = this._threeRenderer
-    const RendererClass = this.rendererClass || WebGLRenderer
+    let renderer = this._threeRenderer;
+    const RendererClass = this.rendererClass || WebGLRenderer;
     if (!renderer || !(renderer instanceof RendererClass)) {
       if (renderer) {
-        renderer.dispose()
+        renderer.dispose();
       }
       // Init the context manually so we can prefer webgl2
-      contextAttributes = assign({
-        alpha: true,
-        antialias
-      }, contextAttributes)
-      const context = canvas.getContext('webgl2', contextAttributes) || undefined
+      contextAttributes = assign(
+        {
+          alpha: true,
+          antialias,
+        },
+        contextAttributes,
+      );
+      const context =
+        canvas.getContext('webgl2', contextAttributes) || undefined;
       if (!context) {
-        console.info('webgl2 init failed, trying webgl')
+        console.info('webgl2 init failed, trying webgl');
       }
-      renderer = this._threeRenderer = new RendererClass(assign({
-        canvas,
-        context
-      }, contextAttributes))
+      renderer = this._threeRenderer = new RendererClass(
+        assign(
+          {
+            canvas,
+            context,
+          },
+          contextAttributes,
+        ),
+      );
     }
 
-    const shadows = this.shadows
-    renderer.shadowMap.enabled = !!shadows
+    const shadows = this.shadows;
+    renderer.shadowMap.enabled = !!shadows;
     if (shadows && typeof shadows === 'object') {
-      assign(renderer.shadowMap, shadows)
+      assign(renderer.shadowMap, shadows);
     }
 
     if (backgroundColor !== this._bgColor) {
-      renderer.setClearColor(new Color(backgroundColor || 0), backgroundColor != null ? 1 : 0)
-      this._bgColor = backgroundColor
+      renderer.setClearColor(
+        new Color(backgroundColor || 0),
+        backgroundColor != null ? 1 : 0,
+      );
+      this._bgColor = backgroundColor;
     }
 
-    renderer.outputEncoding = this.outputEncoding || LinearEncoding
-    renderer.toneMapping = this.toneMapping || NoToneMapping
+    renderer.outputColorSpace = this.outputColorSpace || LinearSRGBColorSpace;
+    renderer.toneMapping = this.toneMapping || NoToneMapping;
 
     // Update render canvas size
-    this._updateDrawingBufferSize(width, height, this.pixelRatio || window.devicePixelRatio || 1)
+    this._updateDrawingBufferSize(
+      width,
+      height,
+      this.pixelRatio || window.devicePixelRatio || 1,
+    );
 
-    super.afterUpdate()
+    super.afterUpdate();
   }
 
   describeChildren() {
-    return [
-      this._getCameraDef(),
-      this._getSceneDef()
-    ]
+    return [this._getCameraDef(), this._getSceneDef()];
   }
 
   /**
@@ -74,12 +122,15 @@ class World3DFacade extends WorldBaseFacade {
    * @protected
    */
   _getCameraDef() {
-    const {camera} = this
-    return assign({
-      key: 'camera',
-      facade: PerspectiveCamera3DFacade,
-      aspect: this.width / this.height
-    }, camera)
+    const { camera } = this;
+    return assign(
+      {
+        key: 'camera',
+        facade: PerspectiveCamera3DFacade,
+        aspect: this.width / this.height,
+      },
+      camera,
+    );
   }
 
   /**
@@ -95,8 +146,8 @@ class World3DFacade extends WorldBaseFacade {
       fog: this.fog,
       background: this.background,
       environment: this.environment,
-      onClick: this.onBackgroundClick ? this._onBgClick : null
-    }
+      onClick: this.onBackgroundClick ? this._onBgClick : null,
+    };
   }
 
   /**
@@ -104,48 +155,57 @@ class World3DFacade extends WorldBaseFacade {
    * @protected
    */
   _updateDrawingBufferSize(width, height, pixelRatio) {
-    const renderer = this._threeRenderer
-    renderer.getSize(tmpVec2)
-    if (tmpVec2.width !== width || tmpVec2.height !== height || renderer.getPixelRatio() !== pixelRatio) {
-      renderer.setDrawingBufferSize(width, height, pixelRatio)
+    const renderer = this._threeRenderer;
+    renderer.getSize(tmpVec2);
+    if (
+      tmpVec2.width !== width ||
+      tmpVec2.height !== height ||
+      renderer.getPixelRatio() !== pixelRatio
+    ) {
+      renderer.setDrawingBufferSize(width, height, pixelRatio);
     }
   }
 
   doRender(/*...frameArgs*/) {
-    let sceneFacade = this.getChildByKey('scene')
-    let scene = sceneFacade.threeObject
-    let camera = this.getChildByKey('camera').threeObject
-    let renderer = this._threeRenderer
+    let sceneFacade = this.getChildByKey('scene');
+    let scene = sceneFacade.threeObject;
+    let camera = this.getChildByKey('camera').threeObject;
+    let renderer = this._threeRenderer;
 
     // Invoke any onBeforeRender listeners
-    let registry = this.eventRegistry
+    let registry = this.eventRegistry;
     function invokeHandler(handler, facadeId) {
-      handler.call(this._object3DFacadesById[facadeId], renderer, scene, camera)
+      handler.call(
+        this._object3DFacadesById[facadeId],
+        renderer,
+        scene,
+        camera,
+      );
     }
-    registry.forEachListenerOfType('beforerender', invokeHandler, this)
+    registry.forEachListenerOfType('beforerender', invokeHandler, this);
 
     // Render scene
-    renderer.render(scene, camera)
+    renderer.render(scene, camera);
 
     // Invoke any onAfterRender listeners
-    registry.forEachListenerOfType('afterrender', invokeHandler, this)
+    registry.forEachListenerOfType('afterrender', invokeHandler, this);
 
-    let onStatsUpdate = this.onStatsUpdate
+    let onStatsUpdate = this.onStatsUpdate;
     if (onStatsUpdate) {
-      const {memory, render} = renderer.info
+      const { memory, render } = renderer.info;
       const stats = {
         'WebGL Draw Calls': render.calls,
         'WebGL Geometries': memory.geometries,
         'WebGL Textures': memory.textures,
-        'WebGL Triangles': render.triangles
-      }
+        'WebGL Triangles': render.triangles,
+      };
       if (render.points) {
-        stats['WebGL Points'] = render.points
+        stats['WebGL Points'] = render.points;
       }
       if (render.lines) {
-        stats['WebGL Lines'] = render.lines
+        stats['WebGL Lines'] = render.lines;
       }
-      onStatsUpdate(stats)
+      onStatsUpdate(stats);
     }
   }
 
@@ -153,28 +213,32 @@ class World3DFacade extends WorldBaseFacade {
    * Implementation of abstract
    */
   getFacadeUserSpaceXYZ(facade) {
-    let matrixEls = facade.threeObject.matrixWorld.elements
-    return this.projectWorldPosition(matrixEls[12], matrixEls[13], matrixEls[14])
+    let matrixEls = facade.threeObject.matrixWorld.elements;
+    return this.projectWorldPosition(
+      matrixEls[12],
+      matrixEls[13],
+      matrixEls[14],
+    );
   }
 
   projectWorldPosition(x, y, z) {
-    tmpVec3.set(x, y, z)
-    let camera = this.getChildByKey('camera')
-    camera.updateMatrices()
-    camera = camera.threeObject
+    tmpVec3.set(x, y, z);
+    let camera = this.getChildByKey('camera');
+    camera.updateMatrices();
+    camera = camera.threeObject;
 
     // Make position relative to camera
-    tmpVec3.applyMatrix4(camera.matrixWorldInverse)
+    tmpVec3.applyMatrix4(camera.matrixWorldInverse);
 
     // Get relative distance to the point, negative if it's behind the camera
-    let signedDistance = tmpVec3.length() * (tmpVec3.z > 0 ? -1 : 1)
+    let signedDistance = tmpVec3.length() * (tmpVec3.z > 0 ? -1 : 1);
 
     // Project x/y to screen coords
-    tmpVec3.applyMatrix4(camera.projectionMatrix)
-    let screenX = (tmpVec3.x + 1) * this.width / 2
-    let screenY = (1 - tmpVec3.y) * this.height / 2
+    tmpVec3.applyMatrix4(camera.projectionMatrix);
+    let screenX = ((tmpVec3.x + 1) * this.width) / 2;
+    let screenY = ((1 - tmpVec3.y) * this.height) / 2;
 
-    return new Vector3(screenX, screenY, signedDistance)
+    return new Vector3(screenX, screenY, signedDistance);
   }
 
   /**
@@ -187,30 +251,34 @@ class World3DFacade extends WorldBaseFacade {
     // All pointer events in a 3D world will be given a `ray` property.
     if (!e.ray) {
       // normalize touch events
-      let posInfo = e
+      let posInfo = e;
       if (e.touches) {
-        let touches = /^touch(end|cancel)$/.test(e.type) ? e.changedTouches : e.touches
+        let touches = /^touch(end|cancel)$/.test(e.type)
+          ? e.changedTouches
+          : e.touches;
         if (touches.length === 1) {
-          posInfo = touches[0]
+          posInfo = touches[0];
         }
       }
 
       // convert mouse position to normalized device coords (-1 to 1)
-      const canvasRect = e.target.getBoundingClientRect() //e.target is the canvas
-      let width = canvasRect.width || this.width //use logical size if no visible rect, e.g. offscreen canvas
-      let height = canvasRect.height || this.height
-      let u = ((posInfo.clientX || 0) - (canvasRect.left || 0)) / width * 2 - 1
-      let v = ((posInfo.clientY || 0) - (canvasRect.top || 0)) / height * -2 + 1
+      const canvasRect = e.target.getBoundingClientRect(); //e.target is the canvas
+      let width = canvasRect.width || this.width; //use logical size if no visible rect, e.g. offscreen canvas
+      let height = canvasRect.height || this.height;
+      let u =
+        (((posInfo.clientX || 0) - (canvasRect.left || 0)) / width) * 2 - 1;
+      let v =
+        (((posInfo.clientY || 0) - (canvasRect.top || 0)) / height) * -2 + 1;
 
       // ensure camera's matrix is up to date
-      let camera = this.getChildByKey('camera')
-      camera.updateMatrices()
+      let camera = this.getChildByKey('camera');
+      camera.updateMatrices();
 
       // calculate the ray and put it on the event
-      e.ray = camera.getRayAtProjectedCoords(u, v)
+      e.ray = camera.getRayAtProjectedCoords(u, v);
     }
 
-    super._normalizePointerEvent(e)
+    super._normalizePointerEvent(e);
   }
 
   /**
@@ -218,136 +286,143 @@ class World3DFacade extends WorldBaseFacade {
    * @return {Array<{facade, distance, ?distanceBias, ...}>|null}
    */
   getFacadesAtEvent(e, filterFn) {
-    return e.ray ? this.getFacadesOnRay(e.ray, filterFn) : null
+    return e.ray ? this.getFacadesOnRay(e.ray, filterFn) : null;
   }
 
   getFacadesOnRay(ray, filterFn) {
     // update bounding sphere octree
-    const octree = this._updateOctree()
+    const octree = this._updateOctree();
 
     // search bounding sphere octree to quickly filter down to a small set of likely hits,
     // then do a true raycast on those facades
-    let allHits = null
+    let allHits = null;
     if (octree) {
-      raycaster.ray = ray
+      raycaster.ray = ray;
       octree.forEachSphereOnRay(ray, (sphere, facadeId) => {
-        const facadesById = this._object3DFacadesById
-        const facade = facadesById && facadesById[facadeId]
+        const facadesById = this._object3DFacadesById;
+        const facade = facadesById && facadesById[facadeId];
         // let the filterFn eliminate things before trying to raycast them
-        const hits = facade && (!filterFn || filterFn(facade)) && facade.raycast && facade.raycast(raycaster)
+        const hits =
+          facade &&
+          (!filterFn || filterFn(facade)) &&
+          facade.raycast &&
+          facade.raycast(raycaster);
         if (hits && hits[0]) {
           // Ignore all but closest
-          hits[0].facade = facade
-          ;(allHits || (allHits = [])).push(hits[0])
+          hits[0].facade = facade;
+          (allHits || (allHits = [])).push(hits[0]);
         }
-      })
+      });
     }
-    return allHits
+    return allHits;
   }
 
   _updateOctree() {
     // update octree with any new bounding spheres
-    let octree = this._boundingSphereOctree
-    const changes = this._octreeChangeset
+    let octree = this._boundingSphereOctree;
+    const changes = this._octreeChangeset;
     if (changes) {
       if (!octree) {
-        octree = this._boundingSphereOctree = new BoundingSphereOctree()
+        octree = this._boundingSphereOctree = new BoundingSphereOctree();
       }
-      const {remove, put} = changes
+      const { remove, put } = changes;
       if (remove) {
         for (let facadeId in remove) {
-          octree.removeSphere(facadeId)
+          octree.removeSphere(facadeId);
         }
       }
       if (put) {
         for (let facadeId in put) {
           // Check for put requests for objects that are now obsolete
-          const facade = this._object3DFacadesById[facadeId]
+          const facade = this._object3DFacadesById[facadeId];
           if (facade && !facade.isDestroying && !(remove && remove[facadeId])) {
-            const sphere = facade.getBoundingSphere && facade.getBoundingSphere()
+            const sphere =
+              facade.getBoundingSphere && facade.getBoundingSphere();
             if (sphere) {
-              octree.putSphere(facadeId, sphere)
+              octree.putSphere(facadeId, sphere);
             } else {
-              octree.removeSphere(facadeId)
+              octree.removeSphere(facadeId);
             }
           }
         }
       }
-      this._octreeChangeset = null
+      this._octreeChangeset = null;
     }
-    return octree
+    return octree;
   }
 
   _queueForOctreeChange(changeType, facade) {
-    const changes = this._octreeChangeset || (this._octreeChangeset = {})
-    const map = changes[changeType] || (changes[changeType] = Object.create(null))
-    map[facade.$facadeId] = facade
+    const changes = this._octreeChangeset || (this._octreeChangeset = {});
+    const map =
+      changes[changeType] || (changes[changeType] = Object.create(null));
+    map[facade.$facadeId] = facade;
   }
 
   _onBgClick(e) {
     // Ignore clicks that bubbled up
     if (e.target === e.currentTarget) {
-      this.onBackgroundClick(e)
+      this.onBackgroundClick(e);
     }
   }
 
   destructor() {
-    super.destructor()
-    this._threeRenderer.dispose()
+    super.destructor();
+    this._threeRenderer.dispose();
   }
-
 }
-
-
 
 World3DFacade.prototype._notifyWorldHandlers = assign(
   Object.create(WorldBaseFacade.prototype._notifyWorldHandlers),
   {
     getCameraPosition(source, outputVec3) {
       // We decompose from the world matrix here to handle pose transforms on top of the configured position
-      outputVec3.setFromMatrixPosition(this.getChildByKey('camera').threeObject.matrixWorld)
+      outputVec3.setFromMatrixPosition(
+        this.getChildByKey('camera').threeObject.matrixWorld,
+      );
     },
     getCameraFacade(source, data) {
-      data.callback(this.getChildByKey('camera'))
+      data.callback(this.getChildByKey('camera'));
     },
     getSceneFacade(source, data) {
-      data.callback(this.getChildByKey('scene'))
+      data.callback(this.getChildByKey('scene'));
     },
     projectWorldPosition(source, data) {
-      let pos = data.worldPosition
-      data.callback(this.projectWorldPosition(pos.x, pos.y, pos.z))
+      let pos = data.worldPosition;
+      data.callback(this.projectWorldPosition(pos.x, pos.y, pos.z));
     },
     object3DAdded(source) {
-      this._object3DFacadesById[source.$facadeId] = source
-      this._queueForOctreeChange('put', source)
+      this._object3DFacadesById[source.$facadeId] = source;
+      this._queueForOctreeChange('put', source);
     },
     object3DBoundsChanged(source) {
-      this._queueForOctreeChange('put', source)
+      this._queueForOctreeChange('put', source);
     },
     object3DRemoved(source) {
-      delete this._object3DFacadesById[source.$facadeId]
-      this._queueForOctreeChange('remove', source)
+      delete this._object3DFacadesById[source.$facadeId];
+      this._queueForOctreeChange('remove', source);
     },
     rayPointerMotion(source, ray) {
       // Dispatch a custom event carrying the Ray, which will be used by our `getFacadesAtEvent`
       // override to search for a hovered facade
-      const e = new MouseEvent('mousemove')
-      e.isRayEvent = true
-      e.ray = ray
-      e.eventSource = source //for tracking gesture states per ray source
-      this._onPointerMotionEvent(e)
+      const e = new MouseEvent('mousemove');
+      e.isRayEvent = true;
+      e.ray = ray;
+      e.eventSource = source; //for tracking gesture states per ray source
+      this._onPointerMotionEvent(e);
     },
     rayPointerAction(source, eventParams) {
       // Dispatch a custom event carrying the Ray, which will be used by our `getFacadesAtEvent`
       // override to search for a hovered facade
-      const e = new (eventParams.type === 'wheel' ? WheelEvent : MouseEvent)(eventParams.type, eventParams)
-      e.isRayEvent = true
-      e.ray = eventParams.ray
-      e.eventSource = source //for tracking gesture states per ray source
-      this._onPointerActionEvent(e)
-    }
-  }
-)
+      const e = new (eventParams.type === 'wheel' ? WheelEvent : MouseEvent)(
+        eventParams.type,
+        eventParams,
+      );
+      e.isRayEvent = true;
+      e.ray = eventParams.ray;
+      e.eventSource = source; //for tracking gesture states per ray source
+      this._onPointerActionEvent(e);
+    },
+  },
+);
 
-
-export default World3DFacade
+export default World3DFacade;

--- a/packages/troika-3d/src/facade/World3DFacade.js
+++ b/packages/troika-3d/src/facade/World3DFacade.js
@@ -5,6 +5,8 @@ import {
   Color,
   Vector2,
   Vector3,
+  SRGBColorSpace,
+  LinearSRGBColorSpace,
   NoToneMapping,
 } from 'three';
 import Scene3DFacade from './Scene3DFacade.js';
@@ -18,8 +20,6 @@ const raycaster = new Raycaster();
 
 const LinearEncoding = 3000;
 const sRGBEncoding = 3001;
-const SRGBColorSpace = 'srgb';
-const LinearSRGBColorSpace = 'srgb-linear';
 
 class World3DFacade extends WorldBaseFacade {
   constructor(canvas) {


### PR DESCRIPTION
Related: #267 #318

Due to the deprecated outputEncoding setter in three and a non existing export LinearEncoding.
This fix sets and gets the srgb outputColorSpace from the output encoding for backwards compatibility. This also sets a default outputColorSpace to Linear sgb. 

Constants from three are included to prevent any further breaking change. I've imported the srgb colorspace constants from three which have been there for quite a few years now.