### PR TITLE
InstancingDerivedMaterial: Deprecated shader method transposeMat3. Use WebGL 2 Native method

### DIFF
--- a/packages/troika-3d/src/facade/instancing/InstancingDerivedMaterial.js
+++ b/packages/troika-3d/src/facade/instancing/InstancingDerivedMaterial.js
@@ -114,6 +114,14 @@ export function upgradeShaders(vertexShader, fragmentShader, instanceUniforms) {
   if (usesNormalMatrix) {
     vertexShader = vertexShader.replace(normalMatrixRefRE, attrRefReplacer)
     vertexAssignments.push(normalMatrixVarAssignment)
+    
+    //Deprecated shader method. Use WebGL 2 Native method instead if missing
+    if (!/\btransposeMat3\s*\(/.test(vertexShader)) {
+      normalMatrixVarAssignment = normalMatrixVarAssignment.replace(
+        'transposeMat3',
+        'transpose',
+      );
+    }
     // Add the inverse() glsl polyfill if there isn't already one defined
     if (!/\binverse\s*\(/.test(vertexShader)) {
       vertexDeclarations.push(inverseFunction)

--- a/packages/troika-3d/src/facade/instancing/InstancingDerivedMaterial.js
+++ b/packages/troika-3d/src/facade/instancing/InstancingDerivedMaterial.js
@@ -45,7 +45,7 @@ const modelViewMatrixVarAssignment = `
 troika_modelViewMatrix = viewMatrix * troika_modelMatrix;
 `
 
-const normalMatrixVarAssignment = `
+let normalMatrixVarAssignment = `
 troika_normalMatrix = transposeMat3(inverse(mat3(troika_modelViewMatrix)));
 `
 
@@ -113,7 +113,7 @@ export function upgradeShaders(vertexShader, fragmentShader, instanceUniforms) {
   }
   if (usesNormalMatrix) {
     vertexShader = vertexShader.replace(normalMatrixRefRE, attrRefReplacer)
-    vertexAssignments.push(normalMatrixVarAssignment)
+    
     
     //Deprecated shader method. Use WebGL 2 Native method instead if missing
     if (!/\btransposeMat3\s*\(/.test(vertexShader)) {
@@ -122,6 +122,10 @@ export function upgradeShaders(vertexShader, fragmentShader, instanceUniforms) {
         'transpose',
       );
     }
+
+    vertexAssignments.push(normalMatrixVarAssignment)
+
+    
     // Add the inverse() glsl polyfill if there isn't already one defined
     if (!/\binverse\s*\(/.test(vertexShader)) {
       vertexDeclarations.push(inverseFunction)


### PR DESCRIPTION
Related: #385 

In the current Three builds they have deprecated the transposeMat3 shader method and using the native WebGL 2 transpose method. 

This fix detects that and replaces back to the transpose method.