### PR TITLE
fix(troika-three-text): survive WebGL context loss during SDF glyph generation

### DIFF
--- a/packages/troika-three-text/src/SDFGenerator.js
+++ b/packages/troika-three-text/src/SDFGenerator.js
@@ -120,12 +120,17 @@ function generateSDF_JS_Worker(width, height, path, viewBox, distance, exponent,
       // webglcontextlost event has flipped atlas.contextLost), in which case this GL write would
       // throw from deep inside webgl-sdf-generator as an unhandled rejection, one per in-flight
       // glyph, and strand the typeset callback. Dropping the write is safe: the TextBuilder's
-      // webglcontextrestored handler regenerates every known glyph into the restored atlas.
+      // webglcontextrestored handler regenerates every known glyph into the restored atlas. A null
+      // probe means context creation was refused under the same GPU pressure - equally benign to
+      // drop, and no restore event will ever fire for a context that never existed. The probe
+      // passes the generator's context attributes so a probe that succeeds can't stick a
+      // wrong-attribute context onto the atlas. Rethrow only when a healthy context proves the
+      // error was unrelated.
       try {
         mainThreadGenerator.webglUtils.renderImageData(canvas, imageData, x, y, width, height, 1 << (3 - channel))
       } catch (err) {
-        const gl = typeof canvas.getContext === 'function' ? canvas.getContext('webgl') : null
-        if (!gl || !gl.isContextLost()) throw err
+        const gl = typeof canvas.getContext === 'function' ? canvas.getContext('webgl', { premultipliedAlpha: false, preserveDrawingBuffer: true, antialias: false, depth: false }) : null
+        if (gl && !gl.isContextLost()) throw err
       }
       timing += now() - start
 

--- a/packages/troika-three-text/src/SDFGenerator.js
+++ b/packages/troika-three-text/src/SDFGenerator.js
@@ -116,7 +116,17 @@ function generateSDF_JS_Worker(width, height, path, viewBox, distance, exponent,
       for (let i = 0; i < textureData.length; i++) {
         imageData[i * 4 + channel] = textureData[i]
       }
-      mainThreadGenerator.webglUtils.renderImageData(canvas, imageData, x, y, width, height, 1 << (3 - channel))
+      // The atlas context may have been lost while the worker was generating (before the async
+      // webglcontextlost event has flipped atlas.contextLost), in which case this GL write would
+      // throw from deep inside webgl-sdf-generator as an unhandled rejection, one per in-flight
+      // glyph, and strand the typeset callback. Dropping the write is safe: the TextBuilder's
+      // webglcontextrestored handler regenerates every known glyph into the restored atlas.
+      try {
+        mainThreadGenerator.webglUtils.renderImageData(canvas, imageData, x, y, width, height, 1 << (3 - channel))
+      } catch (err) {
+        const gl = typeof canvas.getContext === 'function' ? canvas.getContext('webgl') : null
+        if (!gl || !gl.isContextLost()) throw err
+      }
       timing += now() - start
 
       // clean up workers after a while

--- a/packages/troika-three-text/src/TextBuilder.js
+++ b/packages/troika-three-text/src/TextBuilder.js
@@ -324,8 +324,8 @@ function getTextRenderInfo(args, callback) {
       try {
         resizeWebGLCanvasWithoutClearing(sdfCanvas, textureWidth, neededHeight)
       } catch (err) {
-        const gl = sdfCanvas.getContext('webgl')
-        if (!gl || !gl.isContextLost()) throw err
+        const gl = sdfCanvas.getContext('webgl', { premultipliedAlpha: false, preserveDrawingBuffer: true, antialias: false, depth: false })
+        if (gl && !gl.isContextLost()) throw err
       }
       // As of Three r136 textures cannot be resized once they're allocated on the GPU, we must dispose to reallocate it
       sdfTexture.dispose()

--- a/packages/troika-three-text/src/TextBuilder.js
+++ b/packages/troika-three-text/src/TextBuilder.js
@@ -317,7 +317,16 @@ function getTextRenderInfo(args, callback) {
     if (neededHeight > currentHeight) {
       // Since resizing the canvas clears its render buffer, it needs special handling to copy the old contents over
       console.info(`Increasing SDF texture size ${currentHeight}->${neededHeight}`)
-      resizeWebGLCanvasWithoutClearing(sdfCanvas, textureWidth, neededHeight)
+      // If the context was lost, the canvas dimensions are still applied before the GL copy-over
+      // throws; drop the copy in that case - the webglcontextrestored handler regenerates every
+      // glyph into the resized atlas. The dispose below must still run either way so the texture
+      // reallocates at the new canvas size.
+      try {
+        resizeWebGLCanvasWithoutClearing(sdfCanvas, textureWidth, neededHeight)
+      } catch (err) {
+        const gl = sdfCanvas.getContext('webgl')
+        if (!gl || !gl.isContextLost()) throw err
+      }
       // As of Three r136 textures cannot be resized once they're allocated on the GPU, we must dispose to reallocate it
       sdfTexture.dispose()
     }


### PR DESCRIPTION
## Problem

`atlas.contextLost` (added with the context-restoration handling) guards *entry* into glyph generation, but the flag only flips when the async `webglcontextlost` event dispatches — while context loss itself is synchronous (WebKit's per-page context cap evicting the oldest context, GPU process resets, tab backgrounding on iOS). Any glyph generation already in flight reaches the atlas with a dead context in two unguarded places:

1. **`SDFGenerator.js` — JS-worker fallback write.** The GPU generate path is caught (falls back to the JS worker), but the fallback then writes the worker's result into the same lost WebGL1 atlas canvas via `webglUtils.renderImageData`, inside a `.then` with no rejection handler downstream. Result: **one unhandled rejection per in-flight glyph**, and the `Promise.all` in `TextBuilder` never resolves, so **the typeset callback never fires — the `Text` keeps stale render info even after the context is restored.**
2. **`TextBuilder.js` — atlas grow.** `resizeWebGLCanvasWithoutClearing` throws the same way when growth coincides with a lost context.

Which GL call throws first varies by browser build: production Safari throws at `shaderSource` (`TypeError: Argument 1 ('shader') to WebGLRenderingContext.shaderSource must be an instance of WebGLShader` — we collected hundreds of these in Sentry from a page that holds several WebGL contexts), while current WebKit 26.4 and headless Chromium tolerate the null shader and throw `Error: ANGLE_instanced_arrays not supported` from the extension lookup a few calls later. Same path, same consequence in all cases.

## Fix

Drop the two atlas writes when the context reports lost (rethrow otherwise). This is safe by design: the existing `webglcontextrestored` handler already regenerates every known glyph into the restored atlas, so dropped writes self-heal. In the resize case the canvas dimensions are applied before the copy-over throws, and `sdfTexture.dispose()` still runs, so the texture reallocates at the new size for the restore-time regeneration.

With the fix, a typeset that overlaps a context loss completes normally (glyphs regenerate on restore) instead of rejecting and stranding the `Text`.

## Verification

Deterministic reproduction (below) forcing the loss into the in-flight window: `gpuAccelerateSDF = false` routes glyphs through the JS-worker fallback; after the SDF workers' 2s idle termination, a hooked `Worker` constructor loses the atlas context on a microtask right as the fresh SDF worker spawns — i.e. after the whole glyph batch is posted to workers, before any result returns.

| build | result |
| --- | --- |
| `troika-three-text@0.52.4` (npm dist) | unhandled rejection + typeset callback never fires |
| current `main`, built from source | unhandled rejection + typeset callback never fires |
| `main` + this fix, built from source | no rejection, typeset completes, atlas regenerates after `restoreContext()` |

Each row verified in both headless Chromium and WebKit 26.4 (Playwright). `npx jest`: the three failing suites (`troika-3d`, `troika-core`, `troika-flex-layout`) fail identically on unmodified `main`.

<details>
<summary><b>Deterministic repro — single file, npm dists via unpkg (serve statically, watch the console)</b></summary>

```html
<!doctype html>
<title>troika-three-text: unhandled TypeError on SDF atlas write when WebGL context is lost mid-generation</title>
<pre id="out">see console —
</pre>
<script>
window.__result = { rejections: [], secondSyncDone: false, done: false }
</script>
<script type="importmap">
{
  "imports": {
    "three": "https://unpkg.com/three@0.180.0/build/three.module.js",
    "troika-three-text": "https://unpkg.com/troika-three-text@0.52.4/dist/troika-three-text.esm.js",
    "troika-three-utils": "https://unpkg.com/troika-three-utils@0.52.4/dist/troika-three-utils.esm.js",
    "troika-worker-utils": "https://unpkg.com/troika-worker-utils@0.52.0/dist/troika-worker-utils.esm.js",
    "webgl-sdf-generator": "https://unpkg.com/webgl-sdf-generator@1.1.1/dist/webgl-sdf-generator.mjs",
    "bidi-js": "https://unpkg.com/bidi-js@1.0.3/dist/bidi.mjs"
  }
}
</script>
<script type="module">
import { Text } from "troika-three-text"

const out = []
const log = (m) => {
  out.push(m); document.getElementById("out").textContent += m + "\n"
  console.log("[repro] " + m)
}
window.__log = out
window.__result = { rejections: [], secondSyncDone: false, done: false }

window.addEventListener("unhandledrejection", (e) => {
  const msg = String((e.reason && e.reason.message) || e.reason)
  window.__result.rejections.push(msg)
  log("UNHANDLED REJECTION: " + msg)
})

// Deterministic kill switch. troika's JS-SDF worker threads self-terminate after 2s idle,
// so after arming, the next Worker constructed is the fresh SDF worker — built synchronously
// inside the glyph-batch dispatch. Losing the atlas context on the following microtask lands
// the loss after every glyph in the batch has been posted to workers but before any result
// returns: the exact in-flight window the production storm needs. The queued webglcontextlost
// event then wipes webgl-sdf-generator's program cache ahead of the first worker reply, so
// each reply's atlas write must recompile on a dead context.
const OrigWorker = window.Worker
let armed = false
let killed = false
let loseExt = null
window.Worker = class extends OrigWorker {
  constructor(...args) {
    super(...args)
    if (armed && !killed) {
      killed = true
      queueMicrotask(() => {
        log("forcing atlas context loss (glyph batch in flight)")
        loseExt.loseContext()
      })
    }
  }
}

const text = new Text()
text.text = "abc"
text.fontSize = 1
// Route every glyph through the JS-worker fallback → the unguarded atlas write.
text.gpuAccelerateSDF = false
log("first sync dispatched")
text.sync(() => {
  log("first typeset complete")
  const atlasCanvas = text.textRenderInfo.sdfTexture.image
  const gl = atlasCanvas.getContext("webgl")
  loseExt = gl.getExtension("WEBGL_lose_context")
  setTimeout(() => {
    armed = true
    text.text = "XYZQWKLMNOPRSTUV0123456789ghijklm"
    log("second sync dispatched (fresh glyphs)")
    text.sync(() => {
      window.__result.secondSyncDone = true
      log("second typeset complete")
    })
    setTimeout(() => {
      log("restoring context")
      try {
        loseExt.restoreContext()
      } catch (e) {
        log("restoreContext threw: " + e)
      }
      setTimeout(() => {
        window.__result.done = true
        log("done — rejections: " + window.__result.rejections.length + ", secondSyncDone: " + window.__result.secondSyncDone)
      }, 2000)
    }, 1500)
  }, 2600) // > troika's 2s SDF-worker idle timeout, so the batch constructs a fresh Worker
})

</script>
```

Pristine 0.52.4 logs the unhandled rejection and `secondSyncDone: false`; swap the `troika-three-text` import-map entry for a build with this fix and the same run logs no rejections and `secondSyncDone: true`.

</details>
