### PR TITLE
fix(troika-three-utils): avoid inout params in vertex transform so text renders in Safari/ANGLE Metal

### DIFF
--- a/packages/troika-three-utils/src/DerivedMaterial.js
+++ b/packages/troika-three-utils/src/DerivedMaterial.js
@@ -361,15 +361,21 @@ vec2 troika_uv_${key};
 ${vertexShader}
 `
     vertexDefs = `${vertexDefs}
-void troikaVertexTransform${key}(inout vec3 position, inout vec3 normal, inout vec2 uv) {
+void troikaVertexTransform${key}() {
+  vec3 position = troika_position_${key};
+  vec3 normal = troika_normal_${key};
+  vec2 uv = troika_uv_${key};
   ${vertexTransform}
+  troika_position_${key} = position;
+  troika_normal_${key} = normal;
+  troika_uv_${key} = uv;
 }
 `
     vertexMainIntro = `
 troika_position_${key} = vec3(position);
 troika_normal_${key} = vec3(normal);
 troika_uv_${key} = vec2(uv);
-troikaVertexTransform${key}(troika_position_${key}, troika_normal_${key}, troika_uv_${key});
+troikaVertexTransform${key}();
 ${vertexMainIntro}
 `
     vertexShader = vertexShader.replace(/\b(position|normal|uv)\b/g, (match, match1, index, fullStr) => {


### PR DESCRIPTION
Fixes #390.

## Problem

`createDerivedMaterial` emits the vertex transform as a function taking `inout` parameters, called with the hoisted shader globals:

```glsl
void troikaVertexTransform${key}(inout vec3 position, inout vec3 normal, inout vec2 uv) {
  ...
}
...
troikaVertexTransform${key}(troika_position_${key}, troika_normal_${key}, troika_uv_${key});
```

On Safari (macOS, ANGLE Metal backend), ANGLE hoists those globals into a `__metal_generic`-address-space struct, then wraps each `inout` argument in an `ANGLE_InOut<T>` helper whose conversion operator returns `thread T&`. The MSL compiler rejects binding the `__metal_generic` global to a `thread` reference, so **every** derived material fails to link:

```
THREE.WebGLProgram: Shader Error 1282 - VALIDATE_STATUS false
Program Info Log: Internal error while linking shader. MSL compilation error:
  error: reference to type 'thread float3' could not bind to an lvalue of type '__metal_generic float3'
      operator thread T &() { return mTemp; }
```

followed by an endless stream of `WebGL: INVALID_OPERATION: useProgram: program not valid`. The result is that no `troika-three-text` renders in Safari. Chrome/Firefox are unaffected because their ANGLE builds use different backends. This is the ANGLE translator defect tracked upstream in WebKit bug [250169](https://bugs.webkit.org/show_bug.cgi?id=250169) (see also [319958](https://bugs.webkit.org/show_bug.cgi?id=319958)) — the underlying bug is Safari's, but troika can sidestep it entirely.

## Fix

Emit the transform as a **parameterless** function with explicit copy-in / copy-out locals instead of `inout` parameters. It's semantically identical to the previous version (same local names, same read-then-write-back semantics), but never passes a global by reference, so it compiles cleanly under ANGLE Metal.

## Verification

Running this as a `patch-package` patch against `0.52.4` in production: text renders correctly again in Safari, with visually identical output in Chrome and Firefox.

---

Reported and fixed while debugging this in our app; PR opened at maintainer's request (per #390) so the fix is attributed correctly.
